### PR TITLE
fix: make Sentry logging work again

### DIFF
--- a/apps/web/sentry.edge.config.ts
+++ b/apps/web/sentry.edge.config.ts
@@ -5,9 +5,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.SENTRY_DSN) {
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
-    dsn: process.env.SENTRY_DSN,
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,

--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -4,9 +4,9 @@
 
 import * as Sentry from "@sentry/nextjs";
 
-if (process.env.SENTRY_DSN) {
+if (process.env.NEXT_PUBLIC_SENTRY_DSN) {
   Sentry.init({
-    dsn: process.env.SENTRY_DSN,
+    dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
 
     // Define how likely traces are sampled. Adjust this value in production, or use tracesSampler for greater control.
     tracesSampleRate: 1,

--- a/apps/web/src/instrumentation.ts
+++ b/apps/web/src/instrumentation.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
-  if (!process.env.SENTRY_DSN)
+  if (!process.env.NEXT_PUBLIC_SENTRY_DSN)
     return;
 
   if (process.env.NEXT_RUNTIME === "nodejs") {


### PR DESCRIPTION
Sentry logging has been broken for a while now - we weren't using `env.SENTRY_DSN`, but `process.env.SENTRY_DSN` instead - which makes a big difference, as `env.SENTRY_DSN` read the `NEXT_PUBLIC_SENTRY_DSN` envvar instead!