### PR TITLE
fix: call `close()` on `VideoSample` resources

### DIFF
--- a/apps/web/src/client/videoProcessing.ts
+++ b/apps/web/src/client/videoProcessing.ts
@@ -204,6 +204,7 @@ export async function videoConcat(streams: Blob[]) {
                 sample.setDuration(sample.duration * timeScale);
 
                 await source.add(sample);
+                sample.close();
 
                 localLastTimestamp = origTimestamp;
             }


### PR DESCRIPTION
This might close #83.