### PR TITLE
fix: log tRPC errors to Sentry and console

### DIFF
--- a/apps/web/src/pages/api/trpc/[trpc].ts
+++ b/apps/web/src/pages/api/trpc/[trpc].ts
@@ -1,11 +1,26 @@
+import * as Sentry from "@sentry/nextjs";
 import * as trpcNext from "@trpc/server/adapters/next";
 
 import { appRouter } from "@/server/routers/_app";
 import { createContext } from "@/server/trpc";
+import { logError } from "@/server/serverCommon";
 
 // export API handler
 // @link https://trpc.io/docs/v11/server/adapters
 export default trpcNext.createNextApiHandler({
-  router: appRouter,
-  createContext,
+    router: appRouter,
+    createContext,
+    onError({ path, error }) {
+        logError("trpc", `error for ${path ?? "unknown"}! ${error.message}`, {
+            code: error.code,
+            cause: error.cause
+        });
+
+        Sentry.captureException(error, {
+            extra: {
+                path,
+                code: error.code,
+            },
+        });
+    },
 });

--- a/apps/web/src/server/trpc.ts
+++ b/apps/web/src/server/trpc.ts
@@ -2,6 +2,7 @@ import "@/server/allow-only-server";
 
 import { initTRPC, TRPCError } from "@trpc/server";
 import { NextApiRequest, NextApiResponse } from "next";
+import { z, ZodError } from "zod";
 
 import { getAuthenticatedUser } from "@/server/auth";
 
@@ -23,7 +24,17 @@ export async function createContext(opts: { req: NextApiRequest; res: NextApiRes
   };
 }
 
-const t = initTRPC.context<Context>().create();
+const t = initTRPC.context<Context>().create({
+    errorFormatter({ shape, error }) {
+        return {
+            ...shape,
+            data: {
+                ...shape.data,
+                zodError: error.cause instanceof ZodError ? z.treeifyError(error.cause) : null,
+            },
+        };
+    },
+});
 
 export const router = t.router;
 export const procedure = t.procedure;


### PR DESCRIPTION
tRPC's guardrails can sometimes catch an inadvertent error in the output of an API endpoint, but currently, we get no information about what failed - users just get an error message like `Output validation failed`. This PR attempts to forward all these errors to stdout and Sentry.