### PR TITLE
fix: handle missing profile picture error and prompt Slack login

### DIFF
--- a/apps/web/src/pages/auth.tsx
+++ b/apps/web/src/pages/auth.tsx
@@ -53,7 +53,8 @@ export default function Auth() {
 
     if (!error) {
       initOAuth();
-    } else if (error === "no-profile-picture") {
+    }
+    else if (error === "no-profile-picture") {
       setRequireSlackLogin(true);
     }
 


### PR DESCRIPTION
This pull request updates the authentication flow in `apps/web/src/pages/auth.tsx` to better handle cases where a user's Hackatime profile is missing required information, such as a profile picture or email. Users who encounter these issues are now prompted to log in with Slack to complete their profile. The UI and error messaging have been updated to support this flow.

**Authentication flow improvements:**

* Added a new state variable `requireSlackLogin` to track when Slack login is required due to missing profile information.
* Updated the OAuth initialization logic to check for specific error conditions (`no-profile-picture`) and set `requireSlackLogin` accordingly.

**User interface and error messaging:**

* Added new error messages for missing profile picture and email in the Hackatime account.
* Updated the UI to display a Slack login prompt when `requireSlackLogin` is true, including a link for users to log in via Slack.

fixes #95 