### PR TITLE
fix: use proper redirect when deleting timelapses

### DIFF
--- a/apps/web/src/pages/timelapse/[id].tsx
+++ b/apps/web/src/pages/timelapse/[id].tsx
@@ -354,7 +354,7 @@ export default function Page() {
       const result = await trpc.timelapse.delete.mutate({ id: timelapse.id });
 
       if (result.ok) {
-        router.reload();
+        router.push(`/user/@${timelapse.owner.handle}`);
       }
       else {
         setRegularError(`Failed to delete: ${result.error}`);


### PR DESCRIPTION
## Fix: Redirect to user profile after deleting timelapse instead of reloading

### Problem
Deleting an unpublished timelapse shows an error popup even though deletion succeeds. After deletion, `router.reload()` refetches the deleted timelapse, causing a NOT_FOUND error.

### Solution
Replace `router.reload()` with a redirect to the user's profile page (`/user/@${timelapse.owner.handle}`) after successful deletion. This avoids refetching the deleted timelapse and prevents the error.

### Changes
- Modified `handleDeleteTimelapse` in `apps/web/src/pages/timelapse/[id].tsx` to redirect instead of reloading
