### PR TITLE
chore(timelapse): remove unused variables

### DIFF
--- a/apps/web/src/pages/timelapse/create.tsx
+++ b/apps/web/src/pages/timelapse/create.tsx
@@ -221,7 +221,6 @@ export default function Page() {
 
       const now = new Date();
       setStartedAt(now);
-      setFrameCount(0);
       setIsCreated(true);
 
       const timelapseId = await deviceStorage.saveTimelapse({


### PR DESCRIPTION
Self explanatory

Context for future people scrolling commits because they're curious:
messages from asc
[Slack thread link](https://hackclub.slack.com/archives/C09NVLWU61E/p1769470920977949?thread_ts=1769210914.231909&cid=C09NVLWU61E)
yes! this was used before the UI overhaul
we used to display the frames in a lil counter under the duration haha
but I realized that's completely useless information so it was yeeted