### PR TITLE
feat: register current device on first access

### DIFF
--- a/apps/web/src/client/components/ui/layout/SettingsView.tsx
+++ b/apps/web/src/client/components/ui/layout/SettingsView.tsx
@@ -12,6 +12,7 @@ import { WindowedModal } from "../WindowedModal";
 import { Button } from "../Button";
 import { PasskeyModal } from "../PasskeyModal";
 import { ErrorModal } from "../ErrorModal";
+import { registerCurrentDevice } from "@/client/encryption";
 
 export function SettingsView({ isOpen, setIsOpen }: {
   isOpen: boolean,
@@ -37,7 +38,17 @@ export function SettingsView({ isOpen, setIsOpen }: {
       return;
 
     (async () => {
-      setLocalDevices(await deviceStorage.getAllDevices());
+      let allDevices = await deviceStorage.getAllDevices();
+      
+      if (!allDevices.some(d => d.thisDevice)) {
+        try {
+          await registerCurrentDevice();
+          allDevices = await deviceStorage.getAllDevices();
+        }
+        catch {}
+      }
+      
+      setLocalDevices(allDevices);
 
       const res = await trpc.user.getDevices.query({});
       console.log("(SettingsView.tsx) user.getDevices =", res);


### PR DESCRIPTION
This pull request improves device registration logic in the settings view and refactors related code to enhance maintainability and reliability. The main focus is to ensure that the current device is registered if it is missing and to centralize device registration logic in a reusable function.

**Device registration improvements:**

* Added a new `registerCurrentDevice` function in `encryption.ts` to handle registering the current device with the server, generating a passkey, saving the device locally, and syncing device storage.
* Updated `getCurrentDevice` in `encryption.ts` to delegate device registration to the new `registerCurrentDevice` function, reducing code duplication and improving maintainability.

**Settings view enhancements:**

* Modified `SettingsView` in `SettingsView.tsx` to check if the current device is missing from local storage, and if so, register it using the new `registerCurrentDevice` function before updating the device list.
* Imported `registerCurrentDevice` in `SettingsView.tsx` to support the new device registration logic.

fixes #132 