### PR TITLE
fix: properly pluralize online users

### DIFF
--- a/apps/client/src/components/layout/Header.tsx
+++ b/apps/client/src/components/layout/Header.tsx
@@ -49,7 +49,9 @@ export function Header() {
 
             <div className="flex gap-1.5 px-6 py-2 h-min justify-center items-center rounded-2xl bg-dark border border-black shadow text-nowrap">
               <div aria-hidden className="w-2 h-2 rounded-full bg-green" />
-              <div>{usersActive} people recording right now</div>
+              <div>
+                {usersActive === 1 ? "1 person" : `${usersActive} people`} recording right now
+              </div>
             </div>
           </div>
 


### PR DESCRIPTION
when only one person was online it displays 1 people online small grammar fix
<img width="386" height="90" alt="Screenshot 2026-03-10 at 10 21 54 AM" src="https://github.com/user-attachments/assets/96e99682-b4ae-4003-905a-fa9068ed5d55" />

