### PR TITLE
fix: coerce numeric query params from strings in GET endpoints

### DIFF
--- a/packages/api/src/contracts/hackatime.ts
+++ b/packages/api/src/contracts/hackatime.ts
@@ -38,7 +38,7 @@ export const hackatimeRouterContract = {
      timelapsesForProject: contract("GET", "/hackatime/timelapsesForProject")
         .route({ description: "Gets the timelapses of a given Hackatime user associated with the given Hackatime project key." })
         .input(z.object({
-            hackatimeUserId: z.union([z.number().min(1), z.string()])
+            hackatimeUserId: z.union([z.coerce.number().min(1), z.string()])
                 .describe("The Hackatime user ID of the Lapse user that should be the subject of this API call."),
 
             projectKey: z.string().min(1).max(256)

--- a/packages/api/src/contracts/timelapse.ts
+++ b/packages/api/src/contracts/timelapse.ts
@@ -219,7 +219,7 @@ export const timelapseRouterContract = {
                 cursor: LapseId.optional()
                     .describe("The ID of the last timelapse from the previous page. Omit to start from the beginning."),
 
-                limit: z.number().int().min(1).max(100).default(20)
+                limit: z.coerce.number().int().min(1).max(100).default(20)
                     .describe("The maximum number of timelapses to return per page."),
             })
         )

--- a/packages/api/src/contracts/user.ts
+++ b/packages/api/src/contracts/user.ts
@@ -158,7 +158,7 @@ export const userRouterContract = {
                 handle: UserHandle.optional()
                     .describe("The handle of the profile to query. Can be undefined if another field is specified."),
 
-                hackatimeId: z.number().min(1).optional()
+                hackatimeId: z.coerce.number().min(1).optional()
                     .describe("The Hackatime ID of the profile to query. Can be undefined if another field is specified."),
             })
         )


### PR DESCRIPTION
## Summary
- GET endpoint query parameters arrive as strings, but `z.number()` rejects them (e.g. `?limit=1` fails with "expected number, received string")
- Changed `z.number()` to `z.coerce.number()` on all affected GET endpoint inputs:
  - `timelapse/myPublishedTimelapses` — `limit`
  - `user/query` — `hackatimeId`
  - `hackatime/timelapsesForProject` — `hackatimeUserId`

## Test plan
- [ ] Verify `GET /api/timelapse/myPublishedTimelapses?limit=1` no longer returns 400
- [ ] Verify `GET /api/user/query?hackatimeId=123` works
- [ ] Verify `GET /api/hackatime/timelapsesForProject?hackatimeUserId=1&projectKey=test` works