### PR TITLE
feat: attempt JSON datastore recovery

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -28,6 +28,7 @@
     "@types/platform": "^1.3.6",
     "clsx": "^2.1.1",
     "fetch-retry": "^6.0.0",
+    "jsonrepair": "^3.13.3",
     "mediabunny": "^1.38.0",
     "next": "^16.1.6",
     "platform": "^1.3.6",

--- a/apps/client/src/deviceStorage.ts
+++ b/apps/client/src/deviceStorage.ts
@@ -1,6 +1,9 @@
 import * as v from "valibot";
+import { jsonrepair } from "jsonrepair";
+
 import { hasLegacyData } from "@/pages/migrate";
 import { sleep } from "@/common";
+import posthog from "posthog-js";
 
 /**
  * The metadata about a stored timelapse. This does *not* include the actual video - invoke `deviceStorage.getTimelapseVideoSessions` for this.
@@ -122,9 +125,101 @@ export class DeviceStorage {
     const dir = await this.getLapseDir();
     const fileHandle = await dir.getFileHandle("store.json");
     const file = await fileHandle.getFile();
-    const data = v.parse(StoreSchema, JSON.parse(await file.text()));
 
-    return data;
+    const contents = await file.text();
+
+    try {
+      return v.parse(StoreSchema, JSON.parse(contents));
+    }
+    catch (err) {
+      posthog.capture("json_datastore_recovery_started", { contents, err });
+
+      console.error(`(deviceStorage.ts) JSON store corrupted - rebuilding! ${contents}`, err);
+      localStorage.setItem("lapse:corruptedStoreBackup", contents); // just in case...
+      
+      let restored: any = {};
+      try {
+        restored = JSON.parse(jsonrepair(contents));
+      }
+      catch (err) {
+        console.warn(`(deviceStorage.ts) could not restore JSON - will rebuild completely. risky!`, err);
+      }
+
+      function tryGet<T>(keys: string[], defaultValue: T, coalesce: (x: unknown) => T): T {
+        let current = restored;
+        for (const key of keys) {
+          if (!(key in current))
+            return defaultValue;
+
+          current = restored[key];
+        }
+
+        return coalesce(current);
+      }
+
+      const devices = tryGet(["devices"], [], (x) => {
+        if (!Array.isArray(x))
+          return [];
+
+        return x.filter(x => "thisDevice" in x && x["thisDevice"]);
+      });
+
+      const snapshots = tryGet(["timelapse", "snapshots"], [], (x) => {
+        if (Array.isArray(x))
+          return x.map(x => typeof x === "number" ? x : Number(x));
+
+        return [];
+      });
+
+      const startedAt = tryGet(["timelapse", "startedAt"], Date.now(), (x) => {
+        return typeof x === "number" ? x : Number(x);
+      });
+
+      const sessions: number[] = [];
+
+      // The sessions array is just a shortcut - we can recompute it by listing the contents of the directory
+      // and querying all files in the Lapse directory with the format of "session-<ID>.webm".
+      for await (const [filename] of dir.entries()) {
+        const match = /session-([0-9]+)\.webm/.exec(filename);
+        if (!match) {
+          console.log(`(deviceStorage.ts) ignoring file ${filename} for session restore`);
+          continue;
+        }
+
+        console.log(`(deviceStorage.ts) session found for restore: ${filename} (ID ${match[1]})`);
+        sessions.push(parseInt(match[1]));
+      }
+
+      if (sessions.length == 0) {
+        posthog.capture("json_datastore_recovery_no_timelapse", { contents, devices });
+        console.warn("(deviceStorage.ts) no sessions found while restoring timelapse. no timelapse has been started...?");
+        
+        const store = {
+          devices,
+          timelapse: null
+        };
+        
+        await this.writeStore(store);
+        return store;
+      }
+
+      posthog.capture("json_datastore_recovery_success", { contents, devices, snapshots, startedAt, sessions });
+
+      console.log("(deviceStorage.ts) existing timelapse successfully recovered from corrupted JSON!");
+      console.log("(deviceStorage.ts) recovery payload:", devices, snapshots, startedAt, sessions);
+      
+      const data = {
+        devices,
+        timelapse: {
+          snapshots,
+          startedAt,
+          sessions
+        }
+      };
+
+      await this.writeStore(data);
+      return data;
+    }
   }
 
   private async writeStore(data: Store): Promise<void> {

--- a/apps/client/src/deviceStorage.ts
+++ b/apps/client/src/deviceStorage.ts
@@ -4,6 +4,7 @@ import { jsonrepair } from "jsonrepair";
 import { hasLegacyData } from "@/pages/migrate";
 import { sleep } from "@/common";
 import posthog from "posthog-js";
+import { ascending } from "@hackclub/lapse-shared";
 
 /**
  * The metadata about a stored timelapse. This does *not* include the actual video - invoke `deviceStorage.getTimelapseVideoSessions` for this.
@@ -192,7 +193,7 @@ export class DeviceStorage {
         }
 
         console.log(`(deviceStorage.ts) session found for restore: ${filename} (ID ${match[1]})`);
-        sessions.push(parseInt(match[1]));
+        sessions.push(parseInt(match[1], 10));
       }
 
       if (sessions.length == 0) {
@@ -207,6 +208,8 @@ export class DeviceStorage {
         await this.writeStore(store);
         return store;
       }
+
+      sessions.sort(ascending());
 
       posthog.capture("json_datastore_recovery_success", { contents, devices, snapshots, startedAt, sessions });
 

--- a/apps/client/src/deviceStorage.ts
+++ b/apps/client/src/deviceStorage.ts
@@ -146,12 +146,17 @@ export class DeviceStorage {
       }
 
       function tryGet<T>(keys: string[], defaultValue: T, coalesce: (x: unknown) => T): T {
-        let current = restored;
+        let current: any = restored;
         for (const key of keys) {
-          if (!(key in current))
+          if (
+            current == null ||
+            (typeof current !== "object" && typeof current !== "function") ||
+            !(key in current)
+          ) {
             return defaultValue;
+          }
 
-          current = restored[key];
+          current = current[key];
         }
 
         return coalesce(current);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ importers:
       fetch-retry:
         specifier: ^6.0.0
         version: 6.0.0
+      jsonrepair:
+        specifier: ^3.13.3
+        version: 3.13.3
       mediabunny:
         specifier: ^1.38.0
         version: 1.38.0
@@ -5026,6 +5029,10 @@ packages:
 
   jsonfy@0.1.0:
     resolution: {integrity: sha512-Xw4o10mEUftnLkpAvLMCZAv7sWtJIkqGzAYkuqEGx8l0KcQbbg6V6OYfUrZcXrRMTRt2xXcwNZC/1R1bInGs6w==}
+
+  jsonrepair@3.13.3:
+    resolution: {integrity: sha512-BTznj0owIt2CBAH/LTo7+1I5pMvl1e1033LRl/HUowlZmJOIhzC0zbX5bxMngLkfT4WnzPP26QnW5wMr2g9tsQ==}
+    hasBin: true
 
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
@@ -12418,6 +12425,8 @@ snapshots:
   json5@2.2.3: {}
 
   jsonfy@0.1.0: {}
+
+  jsonrepair@3.13.3: {}
 
   jsonwebtoken@9.0.3:
     dependencies:


### PR DESCRIPTION
Sometimes, users can close their browser in the middle of a write. Browsers do not guard against this, so we have to recover the JSON data store.