### PR TITLE
feat: allow deleting cuts in the draft editor with the delete key

### DIFF
--- a/apps/client/src/components/editor/EditorTimeline.tsx
+++ b/apps/client/src/components/editor/EditorTimeline.tsx
@@ -41,6 +41,21 @@ export function EditorTimeline({ sessions, editList, setEditList, playback, onSa
 
   playingRef.current = playing;
 
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key == "Backspace") {
+        const target = event.target as HTMLElement
+        if (["INPUT", "TEXTAREA"].includes(target?.tagName) == false) {
+          setEditList(editList.filter((_, i) => i !== selectedEditRegionIdx));
+          setSelectedIndex(null);
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown)
+    return () => window.removeEventListener("keydown", handleKeyDown)
+  })
+
   // Thumbnail regeneration - this usually happens just once, unless `sessions` updates for some reason.
   useAsyncEffect(async () => {
     const startedAt = Date.now();

--- a/apps/client/src/components/editor/EditorTimeline.tsx
+++ b/apps/client/src/components/editor/EditorTimeline.tsx
@@ -43,7 +43,7 @@ export function EditorTimeline({ sessions, editList, setEditList, playback, onSa
 
   useEffect(() => {
     function handleKeyDown(event: KeyboardEvent) {
-      if (event.key == "Backspace") {
+      if (event.key == "Backspace" || "Delete") {
         const target = event.target as HTMLElement
         if (["INPUT", "TEXTAREA"].includes(target?.tagName) == false) {
           setEditList(editList.filter((_, i) => i !== selectedEditRegionIdx));


### PR DESCRIPTION
QoL feature: you can delete cuts that you added with the backspace button on your keyboard now! yayyy!