### PR TITLE
fix: derive timelapse duration from compiled video

### DIFF
--- a/apps/server/src/job.ts
+++ b/apps/server/src/job.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueEvents } from "bullmq";
-import type { EditListEntry } from "@hackclub/lapse-api";
+import { TIMELAPSE_FACTOR, type EditListEntry } from "@hackclub/lapse-api";
 import { REALIZE_JOB_QUEUE_NAME, RealizeJobOutputsSchema, type RealizeJobInputs, type RealizeJobOutputs } from "@hackclub/lapse-jobs";
 
 import { logError, logInfo, logWarning } from "@/logging.js";
@@ -39,9 +39,9 @@ realizeEvents.waitUntilReady()
     .then(() => {
         realizeEvents.on("completed", async ({ jobId, returnvalue }) => {
             const result = RealizeJobOutputsSchema.parse(typeof returnvalue === "object" ? returnvalue : JSON.parse(returnvalue));
-            const { videoKey, thumbnailKey, timelapseId } = result;
+            const { videoKey, thumbnailKey, timelapseId, videoDuration } = result;
 
-            logInfo(`Timelapse ${timelapseId} finished processing! job=${jobId}`, { videoKey, thumbnailKey });
+            logInfo(`Timelapse ${timelapseId} finished processing! job=${jobId}`, { videoKey, thumbnailKey, videoDuration });
 
             const draft = await database().draftTimelapse.findFirst({
                 where: {
@@ -83,7 +83,8 @@ realizeEvents.waitUntilReady()
                 data: {
                     associatedJobId: null,
                     s3Key: videoKey,
-                    thumbnailS3Key: thumbnailKey
+                    thumbnailS3Key: thumbnailKey,
+                    ...(videoDuration != null && { duration: videoDuration * TIMELAPSE_FACTOR })
                 },
                 include: { owner: true }
             });

--- a/apps/server/src/job.ts
+++ b/apps/server/src/job.ts
@@ -1,5 +1,5 @@
 import { Queue, QueueEvents } from "bullmq";
-import { TIMELAPSE_FACTOR, type EditListEntry } from "@hackclub/lapse-api";
+import type { EditListEntry } from "@hackclub/lapse-api";
 import { REALIZE_JOB_QUEUE_NAME, RealizeJobOutputsSchema, type RealizeJobInputs, type RealizeJobOutputs } from "@hackclub/lapse-jobs";
 
 import { logError, logInfo, logWarning } from "@/logging.js";
@@ -39,9 +39,9 @@ realizeEvents.waitUntilReady()
     .then(() => {
         realizeEvents.on("completed", async ({ jobId, returnvalue }) => {
             const result = RealizeJobOutputsSchema.parse(typeof returnvalue === "object" ? returnvalue : JSON.parse(returnvalue));
-            const { videoKey, thumbnailKey, timelapseId, videoDuration } = result;
+            const { videoKey, thumbnailKey, timelapseId, realTimeDuration } = result;
 
-            logInfo(`Timelapse ${timelapseId} finished processing! job=${jobId}`, { videoKey, thumbnailKey, videoDuration });
+            logInfo(`Timelapse ${timelapseId} finished processing! job=${jobId}`, { videoKey, thumbnailKey, realTimeDuration });
 
             const draft = await database().draftTimelapse.findFirst({
                 where: {
@@ -84,7 +84,7 @@ realizeEvents.waitUntilReady()
                     associatedJobId: null,
                     s3Key: videoKey,
                     thumbnailS3Key: thumbnailKey,
-                    ...(videoDuration != null && { duration: videoDuration * TIMELAPSE_FACTOR })
+                    ...(realTimeDuration != null && { duration: realTimeDuration })
                 },
                 include: { owner: true }
             });

--- a/apps/server/src/routers/admin.ts
+++ b/apps/server/src/routers/admin.ts
@@ -516,6 +516,8 @@ export default os.router({
         .use(requiredAuth("ADMIN"))
         .use(requiredScopes("elevated"))
         .handler(async () => {
+            // Only recalculate durations for timelapses that haven't been realized yet.
+            // Realized timelapses have their duration set from the compiled video, which is the source of truth.
             const PAGE_SIZE = 100;
             let updated = 0;
             let cursor: string | undefined;
@@ -523,6 +525,7 @@ export default os.router({
             while (true) {
                 const batch = await database().timelapse.findMany({
                     select: { id: true, snapshots: true },
+                    where: { s3Key: null },
                     take: PAGE_SIZE,
                     orderBy: { id: "asc" },
                     ...(cursor ? { skip: 1, cursor: { id: cursor } } : {})
@@ -549,7 +552,7 @@ export default os.router({
                 }
             }
 
-            logInfo(`Recalculated durations for ${updated} timelapses.`);
+            logInfo(`Recalculated durations for ${updated} unrealized timelapses (skipped realized timelapses).`);
 
             return apiOk({ updated });
         }),

--- a/apps/worker/src/workers/realize.ts
+++ b/apps/worker/src/workers/realize.ts
@@ -346,7 +346,7 @@ export const realizeJobWorker = new Worker<RealizeJobInputs, RealizeJobOutputs>(
                 timelapseId,
                 videoKey,
                 thumbnailKey,
-                videoDuration
+                realTimeDuration: videoDuration * TIMELAPSE_FACTOR
             };
         }
         finally {

--- a/apps/worker/src/workers/realize.ts
+++ b/apps/worker/src/workers/realize.ts
@@ -246,7 +246,8 @@ export const realizeJobWorker = new Worker<RealizeJobInputs, RealizeJobOutputs>(
             ]);
 
             // Thumbnail generation - we opt for a simple approach where we just get the frame in the middle of the video.
-            const thumbnailTimestamp = (await measureVideoDuration(outputPath)) / 2;
+            const videoDuration = await measureVideoDuration(outputPath);
+            const thumbnailTimestamp = videoDuration / 2;
 
             // Arguments to generate thumbnails regardless of output format
             let thumbnailContentType = "image/avif";
@@ -344,7 +345,8 @@ export const realizeJobWorker = new Worker<RealizeJobInputs, RealizeJobOutputs>(
             return {
                 timelapseId,
                 videoKey,
-                thumbnailKey
+                thumbnailKey,
+                videoDuration
             };
         }
         finally {

--- a/apps/worker/src/workers/realize.ts
+++ b/apps/worker/src/workers/realize.ts
@@ -247,6 +247,8 @@ export const realizeJobWorker = new Worker<RealizeJobInputs, RealizeJobOutputs>(
 
             // Thumbnail generation - we opt for a simple approach where we just get the frame in the middle of the video.
             const videoDuration = await measureVideoDuration(outputPath);
+            const realTimeDuration = videoDuration * TIMELAPSE_FACTOR;
+            log.info(`output video is ${videoDuration.toFixed(2)}s (real-time: ${realTimeDuration.toFixed(0)}s)`);
             const thumbnailTimestamp = videoDuration / 2;
 
             // Arguments to generate thumbnails regardless of output format
@@ -346,7 +348,7 @@ export const realizeJobWorker = new Worker<RealizeJobInputs, RealizeJobOutputs>(
                 timelapseId,
                 videoKey,
                 thumbnailKey,
-                realTimeDuration: videoDuration * TIMELAPSE_FACTOR
+                realTimeDuration
             };
         }
         finally {

--- a/packages/api/src/contracts/admin.ts
+++ b/packages/api/src/contracts/admin.ts
@@ -242,7 +242,7 @@ export const adminRouterContract = {
         })),
 
     recalculateDurations: contract("POST", "/admin/recalculateDurations")
-        .route({ description: "Recalculates the duration of unrealized timelapses (those still processing, without a compiled video) from their snapshots. Realized timelapses are skipped because their duration is derived from the compiled video. Requires administrator permissions and an `elevated` grant." })
+        .route({ description: "Recalculates the duration of timelapses that have no compiled video (`s3Key` is null) from their snapshots. Timelapses with a compiled video are skipped because their duration is derived from the video. Requires administrator permissions and an `elevated` grant." })
         .input(NO_INPUT)
         .output(apiResult({
             updated: z.number().int().nonnegative()

--- a/packages/api/src/contracts/admin.ts
+++ b/packages/api/src/contracts/admin.ts
@@ -242,7 +242,7 @@ export const adminRouterContract = {
         })),
 
     recalculateDurations: contract("POST", "/admin/recalculateDurations")
-        .route({ description: "Recalculates the duration of every timelapse from its snapshots. Requires administrator permissions and an `elevated` grant." })
+        .route({ description: "Recalculates the duration of unrealized timelapses (those still processing, without a compiled video) from their snapshots. Realized timelapses are skipped because their duration is derived from the compiled video. Requires administrator permissions and an `elevated` grant." })
         .input(NO_INPUT)
         .output(apiResult({
             updated: z.number().int().nonnegative()

--- a/packages/jobs/src/realize.ts
+++ b/packages/jobs/src/realize.ts
@@ -53,10 +53,12 @@ export const RealizeJobOutputsSchema = z.object({
     thumbnailKey: z.string(),
 
     /**
-     * The duration of the compiled output video in seconds, as measured by ffprobe.
+     * The real-time duration of the timelapse in seconds (i.e. `videoDuration * TIMELAPSE_FACTOR`),
+     * as measured by ffprobe on the compiled output video. This value can be stored directly as the
+     * timelapse `duration` without further conversion.
      * Optional for backwards compatibility with in-flight jobs that predate this field.
      */
-    videoDuration: z.number().nonnegative().optional()
+    realTimeDuration: z.number().gt(0).finite().optional()
 });
 
 /**

--- a/packages/jobs/src/realize.ts
+++ b/packages/jobs/src/realize.ts
@@ -53,9 +53,9 @@ export const RealizeJobOutputsSchema = z.object({
     thumbnailKey: z.string(),
 
     /**
-     * The real-time duration of the timelapse in seconds (i.e. `videoDuration * TIMELAPSE_FACTOR`),
-     * as measured by ffprobe on the compiled output video. This value can be stored directly as the
-     * timelapse `duration` without further conversion.
+     * The real-time duration of the timelapse in seconds, derived from the compiled video duration
+     * (as measured by ffprobe) multiplied by `TIMELAPSE_FACTOR`. This value can be stored directly
+     * as the timelapse `duration` without further conversion.
      * Optional for backwards compatibility with in-flight jobs that predate this field.
      */
     realTimeDuration: z.number().gt(0).finite().optional()

--- a/packages/jobs/src/realize.ts
+++ b/packages/jobs/src/realize.ts
@@ -50,7 +50,13 @@ export const RealizeJobOutputsSchema = z.object({
     /**
      * The S3 key for the thumbnail, stored in the public S3 bucket, shared by both the server and the worker.
      */
-    thumbnailKey: z.string()
+    thumbnailKey: z.string(),
+
+    /**
+     * The duration of the compiled output video in seconds, as measured by ffprobe.
+     * Optional for backwards compatibility with in-flight jobs that predate this field.
+     */
+    videoDuration: z.number().nonnegative().optional()
 });
 
 /**


### PR DESCRIPTION
## Summary

- The `duration` field was computed from snapshot timestamps with a 120s idle timeout filter, which often diverged from the actual video length (ratios of 75x–162x instead of expected 60x)
- Now when the realize worker compiles a video, it returns the measured video duration (already computed via ffprobe for thumbnail generation) and the server overwrites `duration` with `videoDuration × 60`
- Guards `recalculateDurations` admin endpoint to only target unrealized timelapses, preserving video-derived durations

## Test plan

- [ ] Publish a test timelapse and verify `duration / 60 ≈ video_length` in the API response
- [ ] Confirm worker logs include `videoDuration` in the job completion output
- [ ] Confirm `recalculateDurations` only updates timelapses with `s3Key: null`
- [ ] Verify in-flight jobs (without `videoDuration`) still complete without error