### PR TITLE
feat: remove confusion with syncing time to hackatime

### DIFF
--- a/apps/client/src/components/ui/Dropdown.tsx
+++ b/apps/client/src/components/ui/Dropdown.tsx
@@ -173,11 +173,6 @@ export function Dropdown<TKey extends string>({ value, onChange, options, disabl
 
   let isEffectivelyOpen = isOpen && !disabled;
   const anchor = mainRef.current?.getBoundingClientRect();
-  
-  const selected: DropdownOption<TKey> =
-    findOption(value, options) ??
-    findFirstOption(options) ??
-    { label: "", value }; // This should never happen!
 
   const filteredOptions = allowUserCustom && inputValue
     ? filterTree(options, inputValue)
@@ -274,7 +269,7 @@ export function Dropdown<TKey extends string>({ value, onChange, options, disabl
                 if (!isOpen) setIsOpen(true);
               }}
               onFocus={() => setIsOpen(true)}
-              placeholder={(typeof selected.label === "string" ? selected.label : selected.searchLabel) || "Type to search or create..."}
+              placeholder="Type to search or create..."
               disabled={disabled}
               className="flex-1 bg-transparent outline-none placeholder-secondary"
             />
@@ -296,7 +291,7 @@ export function Dropdown<TKey extends string>({ value, onChange, options, disabl
             )}
             onClick={handleClick}
           >
-            <span>{selected.label || value}</span>
+            <span>{value}</span>
             <Icon glyph="down-caret" size={18} className="text-secondary" />
           </div>
         )


### PR DESCRIPTION
Before: 
<img width="752" height="462" alt="image" src="https://github.com/user-attachments/assets/e0ca0c81-418d-456b-9299-d8559955c5f6" />

After:
<img width="757" height="464" alt="image" src="https://github.com/user-attachments/assets/b60f8f98-9529-47c0-a884-243e835a0018" />

Previously, some users would get confused and think a project was already selected for them, and they'd get confused when clicking "sync" didn't work. This fixes that by explicitly telling the user to select a project