### PR TITLE
feat: allow recording only one session at any given time

### DIFF
--- a/apps/client/src/pages/timelapse/create.tsx
+++ b/apps/client/src/pages/timelapse/create.tsx
@@ -602,10 +602,12 @@ export default function Page() {
   function handleStreamInterrupt() {
     
   }
-
+  const didRun = useRef(false);
   // force this code to be ran on the client
   useEffect(() => {
     let release = {};
+    if (didRun.current) { return; }
+    didRun.current = true;
 
     navigator.locks.request("lapse_lock", { ifAvailable: true },
       async (lock) => {

--- a/apps/client/src/pages/timelapse/create.tsx
+++ b/apps/client/src/pages/timelapse/create.tsx
@@ -603,6 +603,25 @@ export default function Page() {
     
   }
 
+  // force this code to be ran on the client
+  useEffect(() => {
+    let release = {};
+
+    navigator.locks.request("lapse_tab", { ifAvailable: true },
+      async (lock) => {
+        if (!lock) {
+          console.log("didn't get tab lock...")
+          alert("You can only have one tab open on the recording page. Close the other tab.")
+          router.push("/")
+        }
+        console.log("got tab lock. I think")
+        console.log(lock)
+        await new Promise((resolve) => {
+          release = resolve
+        })
+      })
+  }, [])
+
   return (
     <RootLayout showHeader={false}>
       <Modal isOpen={setupModalOpen}>

--- a/apps/client/src/pages/timelapse/create.tsx
+++ b/apps/client/src/pages/timelapse/create.tsx
@@ -609,7 +609,7 @@ export default function Page() {
     if (didRun.current) { return; }
     didRun.current = true;
 
-    navigator.locks.request("lapse_lock", { ifAvailable: true },
+    navigator.locks.request("lapse_lock_thing", { ifAvailable: true },
       async (lock) => {
         if (!lock) {
           console.log("didn't get tab lock...")

--- a/apps/client/src/pages/timelapse/create.tsx
+++ b/apps/client/src/pages/timelapse/create.tsx
@@ -607,12 +607,14 @@ export default function Page() {
   useEffect(() => {
     let release = {};
 
-    navigator.locks.request("lapse_tab", { ifAvailable: true },
+    navigator.locks.request("lapse_lock", { ifAvailable: true },
       async (lock) => {
         if (!lock) {
           console.log("didn't get tab lock...")
+          console.log(lock)
           alert("You can only have one tab open on the recording page. Close the other tab.")
           router.push("/")
+          return
         }
         console.log("got tab lock. I think")
         console.log(lock)


### PR DESCRIPTION
Previously, some users would overwrite their own saved recording by accident or have some other bug, and they would lose their entire recording

This alerts them and prevents loss of recordings. It's not the cleanest (because I used `alert` instead of a proper modal) but it gets the job done

