### PR TITLE
feat: recover and publish legacy pipeline draft recordings

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -40,6 +40,7 @@
     "posthog-node": "^5.35.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
+    "tus-js-client": "^4.3.1",
     "valibot": "^1.4.1",
     "webpack": "^5.107.2"
   },

--- a/apps/client/src/api.ts
+++ b/apps/client/src/api.ts
@@ -3,6 +3,7 @@ import type { ContractRouterClient } from "@orpc/contract";
 import { createORPCClient, onError } from "@orpc/client";
 import { OpenAPILink } from "@orpc/openapi-client/fetch";
 import { compositeRouterContract } from "@hackclub/lapse-api";
+import * as tus from "tus-js-client";
 import { sfetch } from "@/safety";
 import posthog from "posthog-js";
 
@@ -43,4 +44,33 @@ const link = new OpenAPILink(compositeRouterContract, {
  * The main API client.
  */
 export const api: JsonifiedClient<ContractRouterClient<typeof compositeRouterContract>> = createORPCClient(link);
+
+/**
+ * Uploads `data` to the server via `tus`, authorized by an upload `token` issued by an endpoint such as
+ * `draftTimelapse.create`. Used to recover unfinished (OPFS-stored) legacy recordings by uploading their
+ * encrypted sessions and thumbnail.
+ */
+export async function apiUpload(
+  token: string,
+  data: File | Blob,
+  onProgress?: (uploaded: number, total: number) => void
+) {
+  return new Promise<void>((resolve, reject) => {
+    const upload = new tus.Upload(data, {
+      endpoint: `${API_URL}/upload`,
+      retryDelays: [0, 3000, 5000, 10000, 20000],
+      headers: {
+        authorization: `Bearer ${token}`
+      },
+      onProgress,
+      onSuccess() { resolve(); },
+      onError(error) {
+        console.error("(api.ts) upload failed!", error, data);
+        reject(error);
+      },
+    });
+
+    upload.start();
+  });
+}
 

--- a/apps/client/src/components/entity/ThumbnailImage.tsx
+++ b/apps/client/src/components/entity/ThumbnailImage.tsx
@@ -10,21 +10,41 @@ import { sfetch } from "@/safety";
 
 const thumbnailCache = new Map<string, string>();
 
-async function decryptThumbnail(timelapseId: string, encryptedThumbnailUrl: string, iv: string, deviceId?: string): Promise<string | null> {
-  const cacheKey = `${timelapseId}${encryptedThumbnailUrl}`;
+/**
+ * Result of decrypting an encrypted thumbnail: a blob-URL on success, or `missingDevice` set when the key needed
+ * to decrypt it isn't on this device (a distinct, recoverable case from a generic failure).
+ */
+export interface DecryptedThumbnail {
+  url: string | null;
+  missingDevice: boolean;
+}
+
+/**
+ * Fetches and decrypts a client-encrypted thumbnail, returning a cached blob-URL. The result is memoized per
+ * `(id, url)` so callers can re-mount without re-fetching/re-decrypting (and without leaking a blob-URL each time).
+ * `mimeType` defaults to JPEG, but legacy recordings store WebP thumbnails.
+ */
+export async function decryptThumbnail(
+  id: string,
+  encryptedThumbnailUrl: string,
+  iv: string,
+  deviceId?: string,
+  mimeType: string = "image/jpeg"
+): Promise<DecryptedThumbnail> {
+  const cacheKey = `${id}${encryptedThumbnailUrl}`;
   if (thumbnailCache.has(cacheKey))
-    return thumbnailCache.get(cacheKey)!;
+    return { url: thumbnailCache.get(cacheKey)!, missingDevice: false };
 
   try {
     const device = deviceId ? await deviceStorage.getDevice(deviceId) : await getCurrentDevice();
     if (!device) {
-      console.warn(`(ThumbnailImage.tsx) no device found for timelapse ${timelapseId}!`);
-      return null;
+      console.warn(`(ThumbnailImage.tsx) no device found for thumbnail ${id}!`);
+      return { url: null, missingDevice: true };
     }
 
     const response = await sfetch(encryptedThumbnailUrl);
     if (!response.ok)
-      throw new Error(`Failed to fetch encrypted thumbnail for ${timelapseId}: ${response.statusText}`);
+      throw new Error(`Failed to fetch encrypted thumbnail for ${id}: ${response.statusText}`);
 
     const url = URL.createObjectURL(
       new Blob([
@@ -33,17 +53,58 @@ async function decryptThumbnail(timelapseId: string, encryptedThumbnailUrl: stri
           fromHex(iv).buffer,
           await response.arrayBuffer()
         )
-      ], { type: "image/jpeg" })
+      ], { type: mimeType })
     );
 
     thumbnailCache.set(cacheKey, url);
-    return url;
+    return { url, missingDevice: false };
   }
   catch (error) {
-    posthog.capture("thumbnail_decrypt_fail", { error, timelapseId, encryptedThumbnailUrl });
-    console.warn(`(ThumbnailImage.tsx) failed to decrypt thumbnail for timelapse ${timelapseId}:`, error);
-    return null;
+    posthog.capture("thumbnail_decrypt_fail", { error, timelapseId: id, encryptedThumbnailUrl });
+    console.warn(`(ThumbnailImage.tsx) failed to decrypt thumbnail for ${id}:`, error);
+    return { url: null, missingDevice: false };
   }
+}
+
+/**
+ * Decrypts an encrypted thumbnail for display. Returns the blob-URL once ready, whether it's still `loading`, and
+ * `missingKey` when the recording's device key isn't on this device. Memoized via `decryptThumbnail`, so it neither
+ * re-fetches nor leaks a blob-URL across re-mounts.
+ */
+export function useDecryptedThumbnail(opts: {
+  id: string;
+  url: string | null | undefined;
+  iv: string;
+  deviceId?: string;
+  mimeType?: string;
+  enabled?: boolean;
+}): { thumbnail: string | null; missingKey: boolean; loading: boolean } {
+  const { id, url, iv, deviceId, mimeType, enabled = true } = opts;
+  const [thumbnail, setThumbnail] = useState<string | null>(null);
+  const [missingKey, setMissingKey] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!enabled || !url) return;
+
+    let cancelled = false;
+    setLoading(true);
+    setMissingKey(false);
+
+    decryptThumbnail(id, url, iv, deviceId, mimeType)
+      .then(res => {
+        if (cancelled) return;
+        setThumbnail(res.url);
+        setMissingKey(res.missingDevice);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => { cancelled = true; };
+  }, [id, url, iv, deviceId, mimeType, enabled]);
+
+  return { thumbnail, missingKey, loading };
 }
 
 export function ThumbnailImage({ timelapseId, thumbnailUrl, isPublished, iv, deviceId, alt, className, onError }: {
@@ -67,7 +128,7 @@ export function ThumbnailImage({ timelapseId, thumbnailUrl, isPublished, iv, dev
 
     setIsLoading(true);
     decryptThumbnail(timelapseId, thumbnailUrl, iv, deviceId)
-      .then(setDecryptedThumbnail)
+      .then(res => setDecryptedThumbnail(res.url))
       .finally(() => setIsLoading(false));
 
     // Cleanup blob URL when component unmounts or thumbnail changes

--- a/apps/client/src/components/entity/ThumbnailImage.tsx
+++ b/apps/client/src/components/entity/ThumbnailImage.tsx
@@ -131,13 +131,10 @@ export function ThumbnailImage({ timelapseId, thumbnailUrl, isPublished, iv, dev
       .then(res => setDecryptedThumbnail(res.url))
       .finally(() => setIsLoading(false));
 
-    // Cleanup blob URL when component unmounts or thumbnail changes
-    return () => {
-      if (decryptedThumbnail?.startsWith("blob:")) {
-        URL.revokeObjectURL(decryptedThumbnail);
-      }
-    };
-  }, [timelapseId, thumbnailUrl, isPublished, iv, deviceId, decryptedThumbnail]);
+    // NB: we deliberately don't revoke the blob URL on unmount. `decryptThumbnail` memoizes it in a shared cache
+    // (keyed by id+url) and hands the same URL to every consumer (incl. `useDecryptedThumbnail`), so revoking it
+    // here would break the cached entry - the next mount would get a dead `blob:` URL and a broken thumbnail.
+  }, [timelapseId, thumbnailUrl, isPublished, iv, deviceId]);
 
   if (isLoading) {
     return (

--- a/apps/client/src/components/layout/RootLayout.tsx
+++ b/apps/client/src/components/layout/RootLayout.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from "react";
 import clsx from "clsx";
 
 import { Header } from "@/components/layout/Header";
+import { LegacyRecoveryBanner } from "@/components/legacy/LegacyRecoveryBanner";
 import { jetBrainsMono, phantomSans } from "@/fonts";
 
 export default function RootLayout({ children, title = "Lapse", description = "Track time with timelapses", showHeader = false }: PropsWithChildren<{
@@ -23,7 +24,9 @@ export default function RootLayout({ children, title = "Lapse", description = "T
         "flex flex-col w-full h-full sm:gap-2.5",
         jetBrainsMono.variable,
         phantomSans.className
-      )}>          
+      )}>
+        <LegacyRecoveryBanner />
+
         { showHeader && <Header /> }
         
         <main className={clsx(

--- a/apps/client/src/components/legacy/LegacyRecoveryBanner.tsx
+++ b/apps/client/src/components/legacy/LegacyRecoveryBanner.tsx
@@ -1,0 +1,28 @@
+import NextLink from "next/link";
+import { useRouter } from "next/router";
+
+import { useLegacyRecoveryCount } from "@/hooks/useLegacyRecoveryCount";
+
+const RECOVER_ROUTE = "/timelapse/recover";
+
+/**
+ * A site-wide black-on-yellow strip nudging the user to migrate any leftover recordings from the old (pre-Lookout)
+ * pipeline. Clicking it opens the recovery page, where they can publish or discard each one. Hidden when there's
+ * nothing to migrate, or while already on the recovery page.
+ */
+export function LegacyRecoveryBanner() {
+  const router = useRouter();
+  const count = useLegacyRecoveryCount();
+
+  if (count <= 0 || router.pathname === RECOVER_ROUTE)
+    return null;
+
+  return (
+    <NextLink
+      href={RECOVER_ROUTE}
+      className="block w-full bg-yellow text-black font-bold text-center px-6 py-2 transition-[filter] hover:brightness-95"
+    >
+      You have {count} unmigrated timelapse{count === 1 ? "" : "s"}. Click here to publish or discard them.
+    </NextLink>
+  );
+}

--- a/apps/client/src/components/legacy/LegacyRecoveryView.tsx
+++ b/apps/client/src/components/legacy/LegacyRecoveryView.tsx
@@ -1,0 +1,257 @@
+import { useCallback, useEffect, useState } from "react";
+import clsx from "clsx";
+import Icon from "@hackclub/icons";
+import type { DraftTimelapse } from "@hackclub/lapse-api";
+import { decryptData, fromHex } from "@hackclub/lapse-shared";
+
+import { deviceStorage } from "@/deviceStorage";
+import { retryable, sfetch } from "@/safety";
+import {
+  type RecoverableItem,
+  loadRecoverableItems,
+  publishItem,
+  discardItem,
+} from "@/legacyRecovery";
+
+import { Modal, ModalHeader, ModalContent } from "@/components/layout/Modal";
+import { LoadingModal } from "@/components/layout/LoadingModal";
+import { ErrorModal } from "@/components/layout/ErrorModal";
+
+function timeAgo(timestamp: number): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Decrypts and renders a draft's preview thumbnail (or a placeholder when the key isn't on this device).
+ */
+function DraftThumbnail({ draft }: { draft: DraftTimelapse }) {
+  const [thumb, setThumb] = useState<string | null>(null);
+  const [missingKey, setMissingKey] = useState(false);
+
+  useEffect(() => {
+    let objectUrl: string | null = null;
+
+    retryable("recovery draft thumbnail", async () => {
+      const device = await deviceStorage.getDevice(draft.deviceId);
+      if (!device) {
+        setMissingKey(true);
+        return;
+      }
+
+      const res = await sfetch(draft.previewThumbnail);
+      if (!res.ok)
+        throw new Error(`HTTP ${res.status} while fetching draft thumbnail`);
+
+      const decrypted = await decryptData(
+        fromHex(device.passkey).buffer,
+        fromHex(draft.iv).buffer,
+        await res.arrayBuffer()
+      );
+
+      objectUrl = URL.createObjectURL(new Blob([decrypted], { type: "image/webp" }));
+      setThumb(objectUrl);
+    });
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [draft]);
+
+  if (thumb)
+    return <img src={thumb} alt="" className="w-full aspect-video rounded-md object-cover" />;
+
+  return (
+    <div className="w-full aspect-video rounded-md bg-darker flex items-center justify-center">
+      <Icon glyph={missingKey ? "private" : "clock-fill"} size={48} className="text-muted" />
+    </div>
+  );
+}
+
+function ItemThumbnail({ item }: { item: RecoverableItem }) {
+  if (item.kind === "draft")
+    return <DraftThumbnail draft={item.draft} />;
+
+  return (
+    <div className="w-full aspect-video rounded-md bg-darker flex items-center justify-center">
+      <Icon glyph="clock-fill" size={48} className="text-muted" />
+    </div>
+  );
+}
+
+/**
+ * Lets the user recover legacy recordings - unfinished local (OPFS) recordings and uploaded-but-unpublished
+ * drafts. The user selects which to keep (publish, as UNLISTED) or discard. Items are handled in batches and the
+ * list refreshes after each action, so the user can return and deal with the rest later.
+ */
+export function LegacyRecoveryView({ userId, onDone }: {
+  userId: string;
+  onDone: () => void;
+}) {
+  const [items, setItems] = useState<RecoverableItem[] | null>(null);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [busy, setBusy] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    const next = await loadRecoverableItems(userId);
+    setSelected(new Set());
+    setItems(next);
+
+    // Nothing left to recover - hand control back to the normal recording flow.
+    if (next.length === 0)
+      onDone();
+  }, [userId, onDone]);
+
+  useEffect(() => {
+    reload();
+  }, [reload]);
+
+  function toggle(id: string) {
+    setSelected(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  async function runOnSelection(
+    verb: "publish" | "discard",
+    action: (item: RecoverableItem) => Promise<void>,
+  ) {
+    if (!items) return;
+
+    const chosen = items.filter(i => selected.has(i.id));
+    if (chosen.length === 0) return;
+
+    const failures: string[] = [];
+
+    for (const [i, item] of chosen.entries()) {
+      setBusy(`${verb === "publish" ? "Publishing" : "Discarding"} ${i + 1} of ${chosen.length}...`);
+      try {
+        await action(item);
+      }
+      catch (err) {
+        failures.push(err instanceof Error ? err.message : `Couldn't ${verb} an item.`);
+      }
+    }
+
+    setBusy(null);
+
+    if (failures.length > 0)
+      setError(`Some items couldn't be ${verb === "publish" ? "published" : "discarded"}:\n${[...new Set(failures)].join("\n")}`);
+
+    await reload();
+  }
+
+  function handleKeep() {
+    return runOnSelection("publish", publishItem);
+  }
+
+  function handleDiscard() {
+    if (!window.confirm("Discard the selected recordings? This cannot be undone."))
+      return;
+
+    return runOnSelection("discard", discardItem);
+  }
+
+  const selectionCount = selected.size;
+
+  return (
+    <Modal isOpen>
+      <ModalHeader
+        icon="history"
+        showCloseButton
+        onClose={onDone}
+        title="Recover old recordings"
+        description="These were recorded with an older version of Lapse. Pick the ones you want to keep - we'll publish them as unlisted - or discard the rest. You can come back to the others later."
+        shortDescription="Keep or discard old recordings"
+      />
+      <ModalContent>
+        {items === null ? (
+          <p className="text-muted text-center">Looking for recordings...</p>
+        ) : (
+          <div className="flex flex-col gap-4">
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+              {items.map(item => {
+                const isSelected = selected.has(item.id);
+                return (
+                  <div
+                    key={item.id}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => toggle(item.id)}
+                    onKeyDown={(e) => e.key === "Enter" && toggle(item.id)}
+                    className={clsx(
+                      "relative flex flex-col items-center gap-3 p-4 w-full rounded-lg border overflow-hidden cursor-pointer transition-colors",
+                      isSelected ? "border-red bg-red/10" : "border-slate hover:bg-darkless",
+                      busy !== null && "opacity-50 pointer-events-none"
+                    )}
+                  >
+                    <div className={clsx(
+                      "absolute top-2 right-2 z-10 w-6 h-6 rounded-full border flex items-center justify-center",
+                      isSelected ? "bg-red border-red" : "bg-dark/80 border-slate"
+                    )}>
+                      {isSelected && <Icon glyph="checkmark" size={20} className="text-white" />}
+                    </div>
+
+                    <ItemThumbnail item={item} />
+
+                    <div className="flex flex-col items-center text-center gap-1">
+                      <span className="font-bold">
+                        {item.kind === "opfs" ? "Unfinished recording" : (item.draft.name ?? "Untitled draft")}
+                      </span>
+                      <span className="text-sm text-muted">
+                        {item.kind === "opfs" ? "On this device" : "Uploaded"} · {timeAgo(item.createdAt)}
+                      </span>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="flex gap-2 w-full">
+              <button
+                onClick={handleKeep}
+                disabled={selectionCount === 0}
+                className="flex-1 bg-red hover:bg-red/90 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold py-2 px-4 rounded-lg transition-colors cursor-pointer text-sm"
+              >
+                Keep{selectionCount > 0 ? ` (${selectionCount})` : ""}
+              </button>
+              <button
+                onClick={handleDiscard}
+                disabled={selectionCount === 0}
+                className="flex-1 border border-red text-red hover:bg-red/10 disabled:opacity-50 disabled:cursor-not-allowed font-bold py-2 px-4 rounded-lg transition-colors cursor-pointer text-sm"
+              >
+                Discard{selectionCount > 0 ? ` (${selectionCount})` : ""}
+              </button>
+            </div>
+
+            <button
+              onClick={onDone}
+              className="text-muted hover:text-white text-sm transition-colors cursor-pointer"
+            >
+              Not now
+            </button>
+          </div>
+        )}
+      </ModalContent>
+
+      <LoadingModal isOpen={busy !== null} title="Working" message={busy ?? ""} />
+
+      <ErrorModal
+        isOpen={!!error}
+        setIsOpen={(open) => !open && setError(null)}
+        message={error ?? ""}
+        onClose={() => {}}
+      />
+    </Modal>
+  );
+}

--- a/apps/client/src/components/legacy/LegacyRecoveryView.tsx
+++ b/apps/client/src/components/legacy/LegacyRecoveryView.tsx
@@ -2,10 +2,7 @@ import { useCallback, useEffect, useState } from "react";
 import clsx from "clsx";
 import Icon from "@hackclub/icons";
 import type { DraftTimelapse } from "@hackclub/lapse-api";
-import { decryptData, fromHex } from "@hackclub/lapse-shared";
 
-import { deviceStorage } from "@/deviceStorage";
-import { retryable, sfetch } from "@/safety";
 import {
   type RecoverableItem,
   loadRecoverableItems,
@@ -13,6 +10,7 @@ import {
   discardItem,
 } from "@/legacyRecovery";
 
+import { useDecryptedThumbnail } from "@/components/entity/ThumbnailImage";
 import { Modal, ModalHeader, ModalContent } from "@/components/layout/Modal";
 import { LoadingModal } from "@/components/layout/LoadingModal";
 import { ErrorModal } from "@/components/layout/ErrorModal";
@@ -32,40 +30,16 @@ function timeAgo(timestamp: number): string {
  * Decrypts and renders a draft's preview thumbnail (or a placeholder when the key isn't on this device).
  */
 function DraftThumbnail({ draft }: { draft: DraftTimelapse }) {
-  const [thumb, setThumb] = useState<string | null>(null);
-  const [missingKey, setMissingKey] = useState(false);
+  const { thumbnail, missingKey } = useDecryptedThumbnail({
+    id: draft.id,
+    url: draft.previewThumbnail,
+    iv: draft.iv,
+    deviceId: draft.deviceId,
+    mimeType: "image/webp",
+  });
 
-  useEffect(() => {
-    let objectUrl: string | null = null;
-
-    retryable("recovery draft thumbnail", async () => {
-      const device = await deviceStorage.getDevice(draft.deviceId);
-      if (!device) {
-        setMissingKey(true);
-        return;
-      }
-
-      const res = await sfetch(draft.previewThumbnail);
-      if (!res.ok)
-        throw new Error(`HTTP ${res.status} while fetching draft thumbnail`);
-
-      const decrypted = await decryptData(
-        fromHex(device.passkey).buffer,
-        fromHex(draft.iv).buffer,
-        await res.arrayBuffer()
-      );
-
-      objectUrl = URL.createObjectURL(new Blob([decrypted], { type: "image/webp" }));
-      setThumb(objectUrl);
-    });
-
-    return () => {
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [draft]);
-
-  if (thumb)
-    return <img src={thumb} alt="" className="w-full aspect-video rounded-md object-cover" />;
+  if (thumbnail)
+    return <img src={thumbnail} alt="" className="w-full aspect-video rounded-md object-cover" />;
 
   return (
     <div className="w-full aspect-video rounded-md bg-darker flex items-center justify-center">

--- a/apps/client/src/components/legacy/LegacyRecoveryView.tsx
+++ b/apps/client/src/components/legacy/LegacyRecoveryView.tsx
@@ -10,10 +10,12 @@ import {
   discardItem,
 } from "@/legacyRecovery";
 
+import { useAuth } from "@/hooks/useAuth";
 import { useDecryptedThumbnail } from "@/components/entity/ThumbnailImage";
-import { Modal, ModalHeader, ModalContent } from "@/components/layout/Modal";
+import RootLayout from "@/components/layout/RootLayout";
 import { LoadingModal } from "@/components/layout/LoadingModal";
 import { ErrorModal } from "@/components/layout/ErrorModal";
+import { Button } from "@/components/ui/Button";
 
 function timeAgo(timestamp: number): string {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
@@ -60,28 +62,29 @@ function ItemThumbnail({ item }: { item: RecoverableItem }) {
 }
 
 /**
- * Lets the user recover legacy recordings - unfinished local (OPFS) recordings and uploaded-but-unpublished
+ * Full-page view for migrating legacy recordings - unfinished local (OPFS) recordings and uploaded-but-unpublished
  * drafts. The user selects which to keep (publish, as UNLISTED) or discard. Items are handled in batches and the
- * list refreshes after each action, so the user can return and deal with the rest later.
+ * list refreshes after each action, so the user can leave and deal with the rest later (the homepage banner keeps
+ * nudging them as long as anything's left).
  */
-export function LegacyRecoveryView({ userId, onDone }: {
-  userId: string;
-  onDone: () => void;
-}) {
+export function LegacyRecoveryView() {
+  const auth = useAuth(true);
+
   const [items, setItems] = useState<RecoverableItem[] | null>(null);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [busy, setBusy] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
+  const userId = auth.currentUser?.id ?? null;
+
   const reload = useCallback(async () => {
+    if (!userId)
+      return;
+
     const next = await loadRecoverableItems(userId);
     setSelected(new Set());
     setItems(next);
-
-    // Nothing left to recover - hand control back to the normal recording flow.
-    if (next.length === 0)
-      onDone();
-  }, [userId, onDone]);
+  }, [userId]);
 
   useEffect(() => {
     reload();
@@ -139,84 +142,94 @@ export function LegacyRecoveryView({ userId, onDone }: {
   const selectionCount = selected.size;
 
   return (
-    <Modal isOpen>
-      <ModalHeader
-        icon="history"
-        showCloseButton
-        onClose={onDone}
-        title="Recover old recordings"
-        description="These were recorded with an older version of Lapse. Pick the ones you want to keep - we'll publish them as unlisted - or discard the rest. You can come back to the others later."
-        shortDescription="Keep or discard old recordings"
-      />
-      <ModalContent>
-        {items === null ? (
-          <p className="text-muted text-center">Looking for recordings...</p>
-        ) : (
-          <div className="flex flex-col gap-4">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-              {items.map(item => {
-                const isSelected = selected.has(item.id);
-                return (
-                  <div
-                    key={item.id}
-                    role="button"
-                    tabIndex={0}
-                    onClick={() => toggle(item.id)}
-                    onKeyDown={(e) => e.key === "Enter" && toggle(item.id)}
-                    className={clsx(
-                      "relative flex flex-col items-center gap-3 p-4 w-full rounded-lg border overflow-hidden cursor-pointer transition-colors",
-                      isSelected ? "border-red bg-red/10" : "border-slate hover:bg-darkless",
-                      busy !== null && "opacity-50 pointer-events-none"
-                    )}
-                  >
-                    <div className={clsx(
-                      "absolute top-2 right-2 z-10 w-6 h-6 rounded-full border flex items-center justify-center",
-                      isSelected ? "bg-red border-red" : "bg-dark/80 border-slate"
-                    )}>
-                      {isSelected && <Icon glyph="checkmark" size={20} className="text-white" />}
-                    </div>
-
-                    <ItemThumbnail item={item} />
-
-                    <div className="flex flex-col items-center text-center gap-1">
-                      <span className="font-bold">
-                        {item.kind === "opfs" ? "Unfinished recording" : (item.draft.name ?? "Untitled draft")}
-                      </span>
-                      <span className="text-sm text-muted">
-                        {item.kind === "opfs" ? "On this device" : "Uploaded"} · {timeAgo(item.createdAt)}
-                      </span>
-                    </div>
-                  </div>
-                );
-              })}
+    <RootLayout showHeader title="Recover recordings">
+      <div className="flex flex-col items-center px-6 sm:px-16 md:px-24 lg:px-32 py-8">
+        <div className="flex flex-col gap-8 w-full max-w-3xl">
+          <header className="flex items-center gap-4 w-full">
+            <div className="p-2 border border-black rounded-md w-14 h-14 shrink-0 justify-center items-center flex">
+              <Icon glyph="history" size={36} />
             </div>
 
-            <div className="flex gap-2 w-full">
-              <button
-                onClick={handleKeep}
-                disabled={selectionCount === 0}
-                className="flex-1 bg-red hover:bg-red/90 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold py-2 px-4 rounded-lg transition-colors cursor-pointer text-sm"
-              >
-                Keep{selectionCount > 0 ? ` (${selectionCount})` : ""}
-              </button>
-              <button
-                onClick={handleDiscard}
-                disabled={selectionCount === 0}
-                className="flex-1 border border-red text-red hover:bg-red/10 disabled:opacity-50 disabled:cursor-not-allowed font-bold py-2 px-4 rounded-lg transition-colors cursor-pointer text-sm"
-              >
-                Discard{selectionCount > 0 ? ` (${selectionCount})` : ""}
-              </button>
+            <div className="flex flex-col">
+              <h1 className="font-bold text-2xl sm:text-3xl">Recover old recordings</h1>
+              <p className="text-muted sm:text-lg">
+                These were recorded with an older version of Lapse. Pick the ones you want to keep - we'll publish
+                them as unlisted - or discard the rest. You can come back to the others later.
+              </p>
             </div>
+          </header>
 
-            <button
-              onClick={onDone}
-              className="text-muted hover:text-white text-sm transition-colors cursor-pointer"
-            >
-              Not now
-            </button>
-          </div>
-        )}
-      </ModalContent>
+          {items === null ? (
+            <p className="text-muted text-center py-12">Looking for recordings...</p>
+          ) : items.length === 0 ? (
+            <div className="flex flex-col items-center text-center gap-6 py-12">
+              <Icon glyph="checkmark" size={64} className="text-green" />
+              <div className="flex flex-col gap-1">
+                <h2 className="font-bold text-xl">You're all caught up</h2>
+                <p className="text-muted">There are no more old recordings to recover.</p>
+              </div>
+              <Button href="/" kind="primary" icon="home">Back to home</Button>
+            </div>
+          ) : (
+            <div className="flex flex-col gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                {items.map(item => {
+                  const isSelected = selected.has(item.id);
+                  return (
+                    <div
+                      key={item.id}
+                      role="button"
+                      tabIndex={0}
+                      onClick={() => toggle(item.id)}
+                      onKeyDown={(e) => e.key === "Enter" && toggle(item.id)}
+                      className={clsx(
+                        "relative flex flex-col items-center gap-3 p-4 w-full rounded-lg border overflow-hidden cursor-pointer transition-colors",
+                        isSelected ? "border-red bg-red/10" : "border-slate hover:bg-darkless",
+                        busy !== null && "opacity-50 pointer-events-none"
+                      )}
+                    >
+                      <div className={clsx(
+                        "absolute top-2 right-2 z-10 w-6 h-6 rounded-full border flex items-center justify-center",
+                        isSelected ? "bg-red border-red" : "bg-dark/80 border-slate"
+                      )}>
+                        {isSelected && <Icon glyph="checkmark" size={20} className="text-white" />}
+                      </div>
+
+                      <ItemThumbnail item={item} />
+
+                      <div className="flex flex-col items-center text-center gap-1">
+                        <span className="font-bold">
+                          {item.kind === "opfs" ? "Unfinished recording" : (item.draft.name ?? "Untitled draft")}
+                        </span>
+                        <span className="text-sm text-muted">
+                          {item.kind === "opfs" ? "On this device" : "Uploaded"} · {timeAgo(item.createdAt)}
+                        </span>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="flex gap-2 w-full">
+                <button
+                  onClick={handleKeep}
+                  disabled={selectionCount === 0}
+                  className="flex-1 bg-red hover:bg-red/90 disabled:opacity-50 disabled:cursor-not-allowed text-white font-bold py-2 px-4 rounded-lg transition-colors cursor-pointer text-sm"
+                >
+                  Publish{selectionCount > 0 ? ` (${selectionCount})` : ""}
+                </button>
+                <button
+                  onClick={handleDiscard}
+                  disabled={selectionCount === 0}
+                  className="flex-1 border border-red text-red hover:bg-red/10 disabled:opacity-50 disabled:cursor-not-allowed font-bold py-2 px-4 rounded-lg transition-colors cursor-pointer text-sm"
+                >
+                  Discard{selectionCount > 0 ? ` (${selectionCount})` : ""}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
 
       <LoadingModal isOpen={busy !== null} title="Working" message={busy ?? ""} />
 
@@ -226,6 +239,6 @@ export function LegacyRecoveryView({ userId, onDone }: {
         message={error ?? ""}
         onClose={() => {}}
       />
-    </Modal>
+    </RootLayout>
   );
 }

--- a/apps/client/src/components/lookout/LookoutRecorder.tsx
+++ b/apps/client/src/components/lookout/LookoutRecorder.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/router";
 import clsx from "clsx";
 import Icon from "@hackclub/icons";
@@ -15,6 +15,8 @@ import {
   storeSession,
   removeStoredSession,
 } from "@/components/lookout/sessions";
+import { hasLegacyData } from "@/legacyRecovery";
+import { LegacyRecoveryView } from "@/components/legacy/LegacyRecoveryView";
 
 import RootLayout from "@/components/layout/RootLayout";
 import { Modal, ModalHeader, ModalContent } from "@/components/layout/Modal";
@@ -438,7 +440,7 @@ function SessionSelector({ onSelectSession, onNewSession, onClose }: {
 }
 
 export default function LookoutRecorder() {
-  useAuth(true);
+  const auth = useAuth(true);
 
   const router = useRouter();
   const [config, setConfig] = useState<LookoutSessionConfig | null>(null);
@@ -450,14 +452,12 @@ export default function LookoutRecorder() {
   const [desktopLaunched, setDesktopLaunched] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [hasDrafts, setHasDrafts] = useState<boolean | null>(null);
-  const [phase, setPhase] = useState<"checking" | "selecting" | "ready">("checking");
+  const [phase, setPhase] = useState<"checking" | "recovering" | "selecting" | "ready">("checking");
   const initialized = useRef(false);
 
-  useEffect(() => {
-    if (initialized.current) return;
-    initialized.current = true;
-
-    api.timelapse.getLookoutDrafts({}).then(res => {
+  const checkLookoutDrafts = useCallback(async () => {
+    try {
+      const res = await api.timelapse.getLookoutDrafts({});
       if (res.ok && res.data.drafts.length > 0) {
         setHasDrafts(true);
         setPhase("selecting");
@@ -465,11 +465,35 @@ export default function LookoutRecorder() {
         setHasDrafts(false);
         setPhase("ready");
       }
-    }).catch(() => {
+    } catch {
       setHasDrafts(false);
       setPhase("ready");
-    });
+    }
   }, []);
+
+  useEffect(() => {
+    if (initialized.current) return;
+    if (auth.isLoading || !auth.currentUser) return;
+    initialized.current = true;
+
+    (async () => {
+      // Surface any legacy recordings (unfinished OPFS captures or unpublished drafts) for recovery first,
+      // unless the user already dismissed the prompt this session.
+      const dismissed = sessionStorage.getItem("lapse:recovery_dismissed") === "1";
+      if (!dismissed && await hasLegacyData(auth.currentUser!.id)) {
+        setPhase("recovering");
+        return;
+      }
+
+      await checkLookoutDrafts();
+    })();
+  }, [auth.isLoading, auth.currentUser, checkLookoutDrafts]);
+
+  function handleRecoveryDone() {
+    sessionStorage.setItem("lapse:recovery_dismissed", "1");
+    setPhase("checking");
+    checkLookoutDrafts();
+  }
 
   async function createSessionAndStart(onReady: (cfg: LookoutSessionConfig) => void) {
     setIsCreating(true);
@@ -558,6 +582,17 @@ export default function LookoutRecorder() {
     return (
       <RootLayout showHeader={false}>
         <div className="flex items-center justify-center h-screen text-muted">Checking for sessions...</div>
+      </RootLayout>
+    );
+  }
+
+  if (phase === "recovering" && auth.currentUser) {
+    return (
+      <RootLayout showHeader={false}>
+        <LegacyRecoveryView
+          userId={auth.currentUser.id}
+          onDone={handleRecoveryDone}
+        />
       </RootLayout>
     );
   }

--- a/apps/client/src/components/lookout/LookoutRecorder.tsx
+++ b/apps/client/src/components/lookout/LookoutRecorder.tsx
@@ -15,7 +15,7 @@ import {
   storeSession,
   removeStoredSession,
 } from "@/components/lookout/sessions";
-import { hasLegacyData } from "@/legacyRecovery";
+import { hasLegacyData, isRecoveryDismissed, dismissRecovery } from "@/legacyRecovery";
 import { LegacyRecoveryView } from "@/components/legacy/LegacyRecoveryView";
 
 import RootLayout from "@/components/layout/RootLayout";
@@ -479,8 +479,7 @@ export default function LookoutRecorder() {
     (async () => {
       // Surface any legacy recordings (unfinished OPFS captures or unpublished drafts) for recovery first,
       // unless the user already dismissed the prompt this session.
-      const dismissed = sessionStorage.getItem("lapse:recovery_dismissed") === "1";
-      if (!dismissed && await hasLegacyData(auth.currentUser!.id)) {
+      if (!isRecoveryDismissed() && await hasLegacyData(auth.currentUser!.id)) {
         setPhase("recovering");
         return;
       }
@@ -490,7 +489,7 @@ export default function LookoutRecorder() {
   }, [auth.isLoading, auth.currentUser, checkLookoutDrafts]);
 
   function handleRecoveryDone() {
-    sessionStorage.setItem("lapse:recovery_dismissed", "1");
+    dismissRecovery();
     setPhase("checking");
     checkLookoutDrafts();
   }

--- a/apps/client/src/components/lookout/LookoutRecorder.tsx
+++ b/apps/client/src/components/lookout/LookoutRecorder.tsx
@@ -15,9 +15,6 @@ import {
   storeSession,
   removeStoredSession,
 } from "@/components/lookout/sessions";
-import { hasLegacyData, isRecoveryDismissed, dismissRecovery } from "@/legacyRecovery";
-import { LegacyRecoveryView } from "@/components/legacy/LegacyRecoveryView";
-
 import RootLayout from "@/components/layout/RootLayout";
 import { Modal, ModalHeader, ModalContent } from "@/components/layout/Modal";
 import { LoadingModal } from "@/components/layout/LoadingModal";
@@ -452,7 +449,7 @@ export default function LookoutRecorder() {
   const [desktopLaunched, setDesktopLaunched] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
   const [hasDrafts, setHasDrafts] = useState<boolean | null>(null);
-  const [phase, setPhase] = useState<"checking" | "recovering" | "selecting" | "ready">("checking");
+  const [phase, setPhase] = useState<"checking" | "selecting" | "ready">("checking");
   const initialized = useRef(false);
 
   const checkLookoutDrafts = useCallback(async () => {
@@ -476,23 +473,10 @@ export default function LookoutRecorder() {
     if (auth.isLoading || !auth.currentUser) return;
     initialized.current = true;
 
-    (async () => {
-      // Surface any legacy recordings (unfinished OPFS captures or unpublished drafts) for recovery first,
-      // unless the user already dismissed the prompt this session.
-      if (!isRecoveryDismissed() && await hasLegacyData(auth.currentUser!.id)) {
-        setPhase("recovering");
-        return;
-      }
-
-      await checkLookoutDrafts();
-    })();
-  }, [auth.isLoading, auth.currentUser, checkLookoutDrafts]);
-
-  function handleRecoveryDone() {
-    dismissRecovery();
-    setPhase("checking");
+    // Legacy recordings (unfinished OPFS captures or unpublished drafts) are recovered from the dedicated
+    // `/timelapse/recover` page, surfaced by the site-wide banner - not from the create flow.
     checkLookoutDrafts();
-  }
+  }, [auth.isLoading, auth.currentUser, checkLookoutDrafts]);
 
   async function createSessionAndStart(onReady: (cfg: LookoutSessionConfig) => void) {
     setIsCreating(true);
@@ -581,17 +565,6 @@ export default function LookoutRecorder() {
     return (
       <RootLayout showHeader={false}>
         <div className="flex items-center justify-center h-screen text-muted">Checking for sessions...</div>
-      </RootLayout>
-    );
-  }
-
-  if (phase === "recovering" && auth.currentUser) {
-    return (
-      <RootLayout showHeader={false}>
-        <LegacyRecoveryView
-          userId={auth.currentUser.id}
-          onDone={handleRecoveryDone}
-        />
       </RootLayout>
     );
   }

--- a/apps/client/src/deviceStorage.ts
+++ b/apps/client/src/deviceStorage.ts
@@ -12,6 +12,12 @@ export interface StoredTimelapse {
   startedAt: number;
   snapshots: number[];
   sessions: number[];
+
+  /** When this recording was restored (published). Unset while it's still unpublished. */
+  restoredAt?: number;
+
+  /** The restore-logic version it was restored under. Lets us resurface it if a newer version supersedes it. */
+  restoredVersion?: number;
 }
 
 /**
@@ -33,7 +39,9 @@ export type LocalTimelapse = v.InferInput<typeof LocalTimelapseSchema>;
 const LocalTimelapseSchema = v.object({
   startedAt: v.number(),
   snapshots: v.array(v.number()),
-  sessions: v.array(v.number())
+  sessions: v.array(v.number()),
+  restoredAt: v.optional(v.number()),
+  restoredVersion: v.optional(v.number())
 });
 
 const DeviceSchema = v.object({
@@ -451,26 +459,85 @@ export class DeviceStorage {
     });
   }
 
+  /**
+   * Drops the stored timelapse's metadata and removes all of its session files. Internal: the caller must already
+   * be inside an `operation` block (this does not serialize or `ensureInit` on its own).
+   */
+  private async removeStoredTimelapse(): Promise<void> {
+    const store = await this.readStore();
+    const sessions = store.timelapse?.sessions ?? [];
+    store.timelapse = null;
+    await this.writeStore(store);
+
+    const dir = await this.getLapseDir();
+    for (const sessionId of sessions) {
+      try {
+        await dir.removeEntry(`session-${sessionId}.webm`);
+      }
+      catch (err) {
+        console.warn(`(deviceStorage.ts) could not delete session ${sessionId}`, err);
+      }
+    }
+  }
+
   async deleteTimelapse(): Promise<void> {
+    return await this.operation(async () => {
+      await this.ensureInit();
+      await this.removeStoredTimelapse();
+      console.log("(deviceStorage.ts) locally stored timelapse deleted");
+    });
+  }
+
+  /**
+   * Marks the locally stored timelapse as restored (published) under restore-logic version `version`, WITHOUT
+   * deleting it. We keep the recording in OPFS as a safety net in case server-side processing turns out to be
+   * faulty - bumping the restore version then resurfaces it for re-publish. `cleanupRestoredTimelapse` reclaims
+   * the space later, once we're confident.
+   */
+  async markTimelapseRestored(version: number): Promise<void> {
     return await this.operation(async () => {
       await this.ensureInit();
 
       const store = await this.readStore();
-      const sessions = store.timelapse?.sessions ?? [];
-      store.timelapse = null;
-      await this.writeStore(store);
-
-      const dir = await this.getLapseDir();
-      for (const sessionId of sessions) {
-        try {
-          await dir.removeEntry(`session-${sessionId}.webm`);
-        }
-        catch (err) {
-          console.warn(`(deviceStorage.ts) could not delete session ${sessionId}`, err);
-        }
+      if (!store.timelapse) {
+        console.warn("(deviceStorage.ts) markTimelapseRestored called, but no timelapse is registered");
+        return;
       }
 
-      console.log("(deviceStorage.ts) locally stored timelapse deleted");
+      store.timelapse.restoredAt = Date.now();
+      store.timelapse.restoredVersion = version;
+      await this.writeStore(store);
+
+      console.log(`(deviceStorage.ts) locally stored timelapse marked restored (v${version})`);
+    });
+  }
+
+  /**
+   * Sweeps the locally stored timelapse only if it was restored at least `maxAgeMs` ago under restore-logic version
+   * `version` (or newer), reclaiming the OPFS space kept as a post-restore safety net. No-op otherwise - in
+   * particular, a copy whose `restoredVersion` is older than `version` is pending re-recovery and is left intact.
+   *
+   * NOTE: deliberately not wired to any caller yet - the sweep ships in a later change.
+   */
+  async cleanupRestoredTimelapse(version: number, maxAgeMs: number): Promise<void> {
+    return await this.operation(async () => {
+      await this.ensureInit();
+
+      const store = await this.readStore();
+      const local = store.timelapse;
+      if (!local || local.restoredAt == null || local.restoredVersion == null)
+        return;
+
+      // A copy restored under an older version is pending re-recovery (the version was bumped because that restore
+      // was deemed faulty) - never sweep it.
+      if (local.restoredVersion < version)
+        return;
+
+      if (Date.now() - local.restoredAt < maxAgeMs)
+        return;
+
+      await this.removeStoredTimelapse();
+      console.log("(deviceStorage.ts) swept restored timelapse from local storage");
     });
   }
 

--- a/apps/client/src/deviceStorage.ts
+++ b/apps/client/src/deviceStorage.ts
@@ -97,17 +97,23 @@ export class DeviceStorage {
   private root: FileSystemDirectoryHandle | null = null;
   private serialQueue = new AsyncQueue();
 
+  /**
+   * Whether this browser exposes the OPFS APIs `DeviceStorage` relies on. Side-effect free, so it can be used to
+   * merely probe for recoverable data without triggering `ensureInit`'s redirect to `/update-browser`.
+   */
+  static isSupported(): boolean {
+    return typeof navigator !== "undefined"
+      && !!navigator.storage?.getDirectory
+      && typeof FileSystemFileHandle !== "undefined"
+      && "createWritable" in FileSystemFileHandle.prototype
+      && !/firefox\//i.test(navigator.userAgent);
+  }
+
   private async ensureInit(): Promise<void> {
     if (this.root)
       return;
 
-    if (/firefox\//i.test(navigator.userAgent)) {
-      handleMissingApi();
-      await sleep(1000);
-      return;
-    }
-
-    if (!("createWritable" in FileSystemFileHandle.prototype)) {
+    if (!DeviceStorage.isSupported()) {
       handleMissingApi();
       await sleep(1000);
       return;

--- a/apps/client/src/hooks/useLegacyRecoveryCount.ts
+++ b/apps/client/src/hooks/useLegacyRecoveryCount.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from "react";
+
+import { countRecoverableItems } from "@/legacyRecovery";
+import { useAuth } from "@/hooks/useAuth";
+import { useCache } from "@/hooks/useCache";
+
+/**
+ * How many legacy recordings the signed-in user still has to migrate (publish or discard). Returns 0 when there's
+ * nothing to recover or nobody is signed in. The last known count is cached in `localStorage`, so the banner can
+ * render instantly on navigation while a fresh count is fetched in the background.
+ */
+export function useLegacyRecoveryCount(): number {
+  const auth = useAuth(false);
+  const [cached, setCached] = useCache<number>("legacyRecoveryCount");
+  const [count, setCount] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!auth.currentUser) {
+      setCount(0);
+      return;
+    }
+
+    let cancelled = false;
+    (async () => {
+      const n = await countRecoverableItems(auth.currentUser!.id);
+      if (cancelled)
+        return;
+
+      setCount(n);
+      setCached(n);
+    })();
+
+    return () => { cancelled = true; };
+  }, [auth.currentUser]);
+
+  if (!auth.currentUser)
+    return 0;
+
+  // Fall back to the cached value until the first fresh count lands, to avoid a flash of "no banner".
+  return count ?? cached ?? 0;
+}

--- a/apps/client/src/legacyRecovery.ts
+++ b/apps/client/src/legacyRecovery.ts
@@ -4,8 +4,22 @@ import { encryptData, fromHex, MIN_SESSION_SIZE_BYTES } from "@hackclub/lapse-sh
 import posthog from "posthog-js";
 
 import { api, apiUpload } from "@/api";
-import { deviceStorage } from "@/deviceStorage";
+import { deviceStorage, DeviceStorage } from "@/deviceStorage";
 import { getCurrentDevice } from "@/encryption";
+
+// Set once the user dismisses the recovery prompt, so we stop nudging them to it for the rest of the session.
+const RECOVERY_DISMISSED_KEY = "lapse:recovery_dismissed";
+
+/** Whether the user has dismissed the legacy-recovery prompt this session. */
+export function isRecoveryDismissed(): boolean {
+  return typeof sessionStorage !== "undefined" && sessionStorage.getItem(RECOVERY_DISMISSED_KEY) === "1";
+}
+
+/** Remembers (for this session) that the user dismissed the legacy-recovery prompt. */
+export function dismissRecovery(): void {
+  if (typeof sessionStorage !== "undefined")
+    sessionStorage.setItem(RECOVERY_DISMISSED_KEY, "1");
+}
 
 // Recovery of recordings made with the pre-Lookout pipeline. There are two leftover sources:
 //
@@ -79,24 +93,13 @@ export async function videoGenerateThumbnail(videoBlob: Blob): Promise<Blob> {
 }
 
 /**
- * Whether this browser can use OPFS. Mirrors `deviceStorage`'s own gating, but WITHOUT its side effect of
- * redirecting unsupported browsers to `/update-browser` - we don't want merely probing for recoverable data
- * (e.g. on the homepage) to bounce Firefox/old-browser users off the page.
- */
-function opfsAvailable(): boolean {
-  return typeof navigator !== "undefined"
-    && !!navigator.storage?.getDirectory
-    && typeof FileSystemFileHandle !== "undefined"
-    && "createWritable" in FileSystemFileHandle.prototype
-    && !/firefox\//i.test(navigator.userAgent);
-}
-
-/**
  * Returns whether there's an unfinished recording sitting in this device's local (OPFS) storage.
  */
 async function hasLocalRecording(): Promise<boolean> {
-  // Browsers without usable OPFS never produced a local recording, so there's nothing to recover there.
-  if (!opfsAvailable())
+  // Browsers without usable OPFS never produced a local recording, so there's nothing to recover there. We use the
+  // side-effect-free `DeviceStorage.isSupported` rather than touching `deviceStorage`, so merely probing for
+  // recoverable data (e.g. on the homepage) doesn't bounce unsupported browsers to `/update-browser`.
+  if (!DeviceStorage.isSupported())
     return false;
 
   const local = await deviceStorage.getTimelapse();
@@ -189,6 +192,12 @@ async function publishLocalRecording(): Promise<void> {
   const local = await deviceStorage.getTimelapse();
   if (!local || sessions.length === 0)
     throw new Error("No local recording was found to publish.");
+
+  // The published timelapse's duration is derived from its snapshots (`durationBySnapshots` needs at least two).
+  // Refusing here keeps the local copy intact instead of publishing a degenerate 0-duration timelapse and then
+  // deleting the only source of the recording.
+  if (local.snapshots.length < 2)
+    throw new Error("This recording is too short to publish.");
 
   const thumbnail = await videoGenerateThumbnail(sessions[0]);
   const device = await getCurrentDevice();

--- a/apps/client/src/legacyRecovery.ts
+++ b/apps/client/src/legacyRecovery.ts
@@ -1,0 +1,261 @@
+import type { DraftTimelapse } from "@hackclub/lapse-api";
+import { THUMBNAIL_SIZE } from "@hackclub/lapse-api";
+import { encryptData, fromHex, MIN_SESSION_SIZE_BYTES } from "@hackclub/lapse-shared";
+import posthog from "posthog-js";
+
+import { api, apiUpload } from "@/api";
+import { deviceStorage } from "@/deviceStorage";
+import { getCurrentDevice } from "@/encryption";
+
+// Recovery of recordings made with the pre-Lookout pipeline. There are two leftover sources:
+//
+//   1. "opfs"  - unfinished recordings still sitting in this device's local storage (OPFS), never uploaded.
+//   2. "draft" - `DraftTimelapse` records already encrypted and uploaded to R2, but never published.
+//
+// Both can be published (re-encoded server-side) or discarded. We deliberately do NOT let the user keep
+// recording either of them - the legacy capture pipeline no longer exists.
+
+/**
+ * A single recoverable legacy recording. There is at most one `opfs` item (local storage only holds one
+ * in-progress recording), plus any number of `draft` items.
+ */
+export type RecoverableItem =
+  | { kind: "opfs"; id: "opfs"; createdAt: number; snapshotCount: number }
+  | { kind: "draft"; id: string; createdAt: number; draft: DraftTimelapse };
+
+/**
+ * A 1x1 black WebP, used when a real thumbnail can't be decoded from the recording.
+ */
+const FALLBACK_THUMBNAIL = "data:image/webp;base64,UklGRiwAAABXRUJQVlA4TB8AAAAvf8JZAAcQEf0PCAkS/4+3EtH/jP/85z//+c9//l8AAA==";
+
+/**
+ * Generates a preview thumbnail (WebP) from a recorded video session by capturing its first decoded frame.
+ * Falls back to a black image if the video can't be decoded.
+ */
+export async function videoGenerateThumbnail(videoBlob: Blob): Promise<Blob> {
+  const canvas = document.createElement("canvas");
+  const video = document.createElement("video");
+  const objectUrl = URL.createObjectURL(videoBlob);
+
+  try {
+    video.autoplay = true;
+    video.muted = true;
+    video.playsInline = true;
+
+    await new Promise<void>((resolve, reject) => {
+      video.onloadeddata = () => resolve();
+      video.onerror = () => reject(new Error("Could not decode video"));
+      video.src = objectUrl;
+    });
+
+    const vw = video.videoWidth || THUMBNAIL_SIZE;
+    const vh = video.videoHeight || THUMBNAIL_SIZE;
+
+    canvas.width = vw >= vh ? THUMBNAIL_SIZE : Math.floor((THUMBNAIL_SIZE * vw) / vh);
+    canvas.height = vh >= vw ? THUMBNAIL_SIZE : Math.floor((THUMBNAIL_SIZE * vh) / vw);
+
+    const ctx = canvas.getContext("2d");
+    if (!ctx)
+      throw new Error("Could not get a 2D canvas context");
+
+    ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+    const blob = await new Promise<Blob | null>(resolve => canvas.toBlob(resolve, "image/webp"));
+    if (!blob)
+      throw new Error("canvas.toBlob() returned null");
+
+    return blob;
+  }
+  catch (err) {
+    posthog.capture("legacy_recovery_thumbnail_failed", { err, size: videoBlob.size });
+    console.warn("(legacyRecovery.ts) could not generate thumbnail - using fallback", err);
+    return await fetch(FALLBACK_THUMBNAIL).then(x => x.blob());
+  }
+  finally {
+    URL.revokeObjectURL(objectUrl);
+    video.remove();
+    canvas.remove();
+  }
+}
+
+/**
+ * Whether this browser can use OPFS. Mirrors `deviceStorage`'s own gating, but WITHOUT its side effect of
+ * redirecting unsupported browsers to `/update-browser` - we don't want merely probing for recoverable data
+ * (e.g. on the homepage) to bounce Firefox/old-browser users off the page.
+ */
+function opfsAvailable(): boolean {
+  return typeof navigator !== "undefined"
+    && !!navigator.storage?.getDirectory
+    && typeof FileSystemFileHandle !== "undefined"
+    && "createWritable" in FileSystemFileHandle.prototype
+    && !/firefox\//i.test(navigator.userAgent);
+}
+
+/**
+ * Returns whether there's an unfinished recording sitting in this device's local (OPFS) storage.
+ */
+async function hasLocalRecording(): Promise<boolean> {
+  // Browsers without usable OPFS never produced a local recording, so there's nothing to recover there.
+  if (!opfsAvailable())
+    return false;
+
+  const local = await deviceStorage.getTimelapse();
+  if (!local || local.sessions.length === 0)
+    return false;
+
+  // Guard against impossibly small / empty recordings left behind by a crashed session.
+  return (await deviceStorage.getTimelapseVideoSize()) > MIN_SESSION_SIZE_BYTES;
+}
+
+/**
+ * Loads every legacy recording that can be recovered for `userId`: the local unfinished recording (if any) plus
+ * all uploaded-but-unpublished draft timelapses.
+ */
+export async function loadRecoverableItems(userId: string): Promise<RecoverableItem[]> {
+  const items: RecoverableItem[] = [];
+
+  try {
+    if (await hasLocalRecording()) {
+      const local = await deviceStorage.getTimelapse();
+      if (local) {
+        items.push({
+          kind: "opfs",
+          id: "opfs",
+          createdAt: local.startedAt,
+          snapshotCount: local.snapshots.length,
+        });
+      }
+    }
+  }
+  catch (err) {
+    console.warn("(legacyRecovery.ts) could not inspect local storage for recoverable recordings", err);
+  }
+
+  const res = await api.draftTimelapse.findByUser({ user: userId });
+  if (res.ok) {
+    for (const draft of res.data.timelapses) {
+      // Drafts that are already being published have an associated (processing) timelapse - skip those.
+      if (draft.associatedTimelapseId)
+        continue;
+
+      items.push({ kind: "draft", id: draft.id, createdAt: draft.createdAt, draft });
+    }
+  }
+
+  return items;
+}
+
+/**
+ * Quick check for whether `userId` has any recoverable legacy data. Used to decide whether to prompt the user.
+ */
+export async function hasLegacyData(userId: string): Promise<boolean> {
+  try {
+    return (await loadRecoverableItems(userId)).length > 0;
+  }
+  catch (err) {
+    console.warn("(legacyRecovery.ts) hasLegacyData check failed", err);
+    return false;
+  }
+}
+
+/**
+ * Publishes an already-uploaded draft timelapse as UNLISTED. Requires the key of the device that recorded it.
+ */
+async function publishDraft(draft: DraftTimelapse): Promise<void> {
+  const device = await deviceStorage.getDevice(draft.deviceId);
+  if (!device)
+    throw new Error("This draft was recorded on a different device, so it can't be published from here.");
+
+  const res = await api.timelapse.publish({
+    id: draft.id,
+    visibility: "UNLISTED",
+    deviceKey: device.passkey,
+  });
+
+  if (!res.ok)
+    throw new Error(res.message);
+}
+
+/**
+ * Uploads the local (OPFS) recording's encrypted sessions to R2, turns it into a draft, and publishes it as
+ * UNLISTED. On success the local recording is removed from device storage.
+ */
+async function publishLocalRecording(): Promise<void> {
+  await deviceStorage.sync();
+
+  const sessions = (await deviceStorage.getTimelapseVideoSessions())
+    .filter(x => x.size > MIN_SESSION_SIZE_BYTES);
+
+  const local = await deviceStorage.getTimelapse();
+  if (!local || sessions.length === 0)
+    throw new Error("No local recording was found to publish.");
+
+  const thumbnail = await videoGenerateThumbnail(sessions[0]);
+  const device = await getCurrentDevice();
+
+  const createRes = await api.draftTimelapse.create({
+    snapshots: local.snapshots,
+    thumbnailSize: thumbnail.size,
+    deviceId: device.id,
+    // Encryption adds up to a block of padding, so give every session a small upload margin.
+    sessions: sessions.map(x => ({ fileSize: x.size + 8192 })),
+  });
+
+  if (!createRes.ok)
+    throw new Error(createRes.message);
+
+  const { iv } = createRes.data.draftTimelapse;
+  const key = fromHex(device.passkey).buffer;
+  const ivBuffer = fromHex(iv).buffer;
+
+  for (const [i, session] of sessions.entries()) {
+    const encrypted = await encryptData(key, ivBuffer, session);
+    await apiUpload(createRes.data.sessionUploadTokens[i], new Blob([encrypted], { type: "video/webm" }));
+  }
+
+  const encryptedThumbnail = await encryptData(key, ivBuffer, thumbnail);
+  await apiUpload(createRes.data.thumbnailUploadToken, new Blob([encryptedThumbnail], { type: "image/webp" }));
+
+  const publishRes = await api.timelapse.publish({
+    id: createRes.data.draftTimelapse.id,
+    visibility: "UNLISTED",
+    deviceKey: device.passkey,
+  });
+
+  if (!publishRes.ok)
+    throw new Error(publishRes.message);
+
+  // Only once the recording is safely published do we drop the local copy.
+  await deviceStorage.deleteTimelapse();
+}
+
+/**
+ * Publishes a recoverable item (UNLISTED). Throws on failure, leaving the item intact so it can be retried.
+ */
+export async function publishItem(item: RecoverableItem): Promise<void> {
+  if (item.kind === "opfs") {
+    await publishLocalRecording();
+    posthog.capture("legacy_recovery_published", { kind: "opfs" });
+    return;
+  }
+
+  await publishDraft(item.draft);
+  posthog.capture("legacy_recovery_published", { kind: "draft", draftId: item.id });
+}
+
+/**
+ * Permanently discards a recoverable item.
+ */
+export async function discardItem(item: RecoverableItem): Promise<void> {
+  if (item.kind === "opfs") {
+    await deviceStorage.deleteTimelapse();
+    posthog.capture("legacy_recovery_discarded", { kind: "opfs" });
+    return;
+  }
+
+  const res = await api.draftTimelapse.delete({ id: item.id });
+  if (!res.ok)
+    throw new Error(res.message);
+
+  posthog.capture("legacy_recovery_discarded", { kind: "draft", draftId: item.id });
+}

--- a/apps/client/src/legacyRecovery.ts
+++ b/apps/client/src/legacyRecovery.ts
@@ -7,20 +7,6 @@ import { api, apiUpload } from "@/api";
 import { deviceStorage, DeviceStorage } from "@/deviceStorage";
 import { getCurrentDevice } from "@/encryption";
 
-// Set once the user dismisses the recovery prompt, so we stop nudging them to it for the rest of the session.
-const RECOVERY_DISMISSED_KEY = "lapse:recovery_dismissed";
-
-/** Whether the user has dismissed the legacy-recovery prompt this session. */
-export function isRecoveryDismissed(): boolean {
-  return typeof sessionStorage !== "undefined" && sessionStorage.getItem(RECOVERY_DISMISSED_KEY) === "1";
-}
-
-/** Remembers (for this session) that the user dismissed the legacy-recovery prompt. */
-export function dismissRecovery(): void {
-  if (typeof sessionStorage !== "undefined")
-    sessionStorage.setItem(RECOVERY_DISMISSED_KEY, "1");
-}
-
 // Recovery of recordings made with the pre-Lookout pipeline. There are two leftover sources:
 //
 //   1. "opfs"  - unfinished recordings still sitting in this device's local storage (OPFS), never uploaded.
@@ -149,15 +135,16 @@ export async function loadRecoverableItems(userId: string): Promise<RecoverableI
 }
 
 /**
- * Quick check for whether `userId` has any recoverable legacy data. Used to decide whether to prompt the user.
+ * Counts how many recoverable legacy recordings `userId` has. Used to drive the "unmigrated timelapses" banner.
+ * Returns 0 (rather than throwing) if the check fails, so a transient error never surfaces a misleading prompt.
  */
-export async function hasLegacyData(userId: string): Promise<boolean> {
+export async function countRecoverableItems(userId: string): Promise<number> {
   try {
-    return (await loadRecoverableItems(userId)).length > 0;
+    return (await loadRecoverableItems(userId)).length;
   }
   catch (err) {
-    console.warn("(legacyRecovery.ts) hasLegacyData check failed", err);
-    return false;
+    console.warn("(legacyRecovery.ts) countRecoverableItems check failed", err);
+    return 0;
   }
 }
 

--- a/apps/client/src/legacyRecovery.ts
+++ b/apps/client/src/legacyRecovery.ts
@@ -16,6 +16,14 @@ import { getCurrentDevice } from "@/encryption";
 // recording either of them - the legacy capture pipeline no longer exists.
 
 /**
+ * Version of the local-recording restore logic. On a successful publish we keep the OPFS copy as a safety net and
+ * tag it with this version rather than deleting it. If a restore turns out to be faulty, bump this constant: copies
+ * tagged with an older version are no longer considered "restored" and resurface in the recovery banner/list for
+ * re-publish. A later sweep (`deviceStorage.cleanupRestoredTimelapse`) reclaims the space once we're confident.
+ */
+export const CURRENT_RESTORE_VERSION = 1;
+
+/**
  * A single recoverable legacy recording. There is at most one `opfs` item (local storage only holds one
  * in-progress recording), plus any number of `draft` items.
  */
@@ -98,6 +106,12 @@ async function getPublishableLocalRecording(): Promise<{ local: LocalTimelapse; 
 
   const local = await deviceStorage.getTimelapse();
   if (!local || local.sessions.length === 0)
+    return null;
+
+  // Already restored under the current logic: kept only as a safety net, not something to offer/publish again. If
+  // CURRENT_RESTORE_VERSION is later bumped (a restore was found faulty), older-versioned copies fall through here
+  // and resurface for re-publish.
+  if (local.restoredVersion != null && local.restoredVersion >= CURRENT_RESTORE_VERSION)
     return null;
 
   // The published timelapse's duration is derived from its snapshots (`durationBySnapshots` needs at least two).
@@ -253,8 +267,9 @@ async function publishLocalRecording(): Promise<void> {
     throw err;
   }
 
-  // Only once the recording is safely published do we drop the local copy.
-  await deviceStorage.deleteTimelapse();
+  // The recording is safely published. We keep the local copy as a safety net (in case server-side processing is
+  // faulty) and just mark it restored, so the banner/list stop offering it. A later sweep reclaims the space.
+  await deviceStorage.markTimelapseRestored(CURRENT_RESTORE_VERSION);
 }
 
 /**

--- a/apps/client/src/legacyRecovery.ts
+++ b/apps/client/src/legacyRecovery.ts
@@ -78,22 +78,46 @@ export async function videoGenerateThumbnail(videoBlob: Blob): Promise<Blob> {
   }
 }
 
+type LocalTimelapse = NonNullable<Awaited<ReturnType<typeof deviceStorage.getTimelapse>>>;
+
 /**
- * Returns whether there's an unfinished recording sitting in this device's local (OPFS) storage.
+ * Loads the local (OPFS) recording, but only if it meets every requirement the publish path enforces: usable OPFS,
+ * at least two snapshots (needed to derive a non-zero duration), and at least one session over the minimum size.
+ * Returns `null` otherwise.
+ *
+ * `hasLocalRecording` and `publishLocalRecording` share this check so the recovery banner never counts/lists a
+ * local recording that publishing would then refuse - which would otherwise leave a permanent "unmigrated
+ * timelapse" nag that only Discard could clear.
  */
-async function hasLocalRecording(): Promise<boolean> {
+async function getPublishableLocalRecording(): Promise<{ local: LocalTimelapse; sessions: Blob[] } | null> {
   // Browsers without usable OPFS never produced a local recording, so there's nothing to recover there. We use the
   // side-effect-free `DeviceStorage.isSupported` rather than touching `deviceStorage`, so merely probing for
   // recoverable data (e.g. on the homepage) doesn't bounce unsupported browsers to `/update-browser`.
   if (!DeviceStorage.isSupported())
-    return false;
+    return null;
 
   const local = await deviceStorage.getTimelapse();
   if (!local || local.sessions.length === 0)
-    return false;
+    return null;
 
-  // Guard against impossibly small / empty recordings left behind by a crashed session.
-  return (await deviceStorage.getTimelapseVideoSize()) > MIN_SESSION_SIZE_BYTES;
+  // The published timelapse's duration is derived from its snapshots (`durationBySnapshots` needs at least two).
+  if (local.snapshots.length < 2)
+    return null;
+
+  // Guard against impossibly small / empty sessions left behind by a crashed recording.
+  const sessions = (await deviceStorage.getTimelapseVideoSessions())
+    .filter(x => x.size > MIN_SESSION_SIZE_BYTES);
+  if (sessions.length === 0)
+    return null;
+
+  return { local, sessions };
+}
+
+/**
+ * Returns whether there's a publishable unfinished recording sitting in this device's local (OPFS) storage.
+ */
+async function hasLocalRecording(): Promise<boolean> {
+  return (await getPublishableLocalRecording()) !== null;
 }
 
 /**
@@ -173,18 +197,13 @@ async function publishDraft(draft: DraftTimelapse): Promise<void> {
 async function publishLocalRecording(): Promise<void> {
   await deviceStorage.sync();
 
-  const sessions = (await deviceStorage.getTimelapseVideoSessions())
-    .filter(x => x.size > MIN_SESSION_SIZE_BYTES);
+  // Refusing here (rather than after `create`) keeps the local copy intact instead of publishing a degenerate
+  // timelapse and then deleting the only source of the recording. Mirrors exactly what `hasLocalRecording` counts.
+  const publishable = await getPublishableLocalRecording();
+  if (!publishable)
+    throw new Error("This recording is too short or incomplete to publish.");
 
-  const local = await deviceStorage.getTimelapse();
-  if (!local || sessions.length === 0)
-    throw new Error("No local recording was found to publish.");
-
-  // The published timelapse's duration is derived from its snapshots (`durationBySnapshots` needs at least two).
-  // Refusing here keeps the local copy intact instead of publishing a degenerate 0-duration timelapse and then
-  // deleting the only source of the recording.
-  if (local.snapshots.length < 2)
-    throw new Error("This recording is too short to publish.");
+  const { local, sessions } = publishable;
 
   const thumbnail = await videoGenerateThumbnail(sessions[0]);
   const device = await getCurrentDevice();
@@ -200,26 +219,39 @@ async function publishLocalRecording(): Promise<void> {
   if (!createRes.ok)
     throw new Error(createRes.message);
 
-  const { iv } = createRes.data.draftTimelapse;
-  const key = fromHex(device.passkey).buffer;
-  const ivBuffer = fromHex(iv).buffer;
+  const draftId = createRes.data.draftTimelapse.id;
 
-  for (const [i, session] of sessions.entries()) {
-    const encrypted = await encryptData(key, ivBuffer, session);
-    await apiUpload(createRes.data.sessionUploadTokens[i], new Blob([encrypted], { type: "video/webm" }));
+  try {
+    const { iv } = createRes.data.draftTimelapse;
+    const key = fromHex(device.passkey).buffer;
+    const ivBuffer = fromHex(iv).buffer;
+
+    for (const [i, session] of sessions.entries()) {
+      const encrypted = await encryptData(key, ivBuffer, session);
+      await apiUpload(createRes.data.sessionUploadTokens[i], new Blob([encrypted], { type: "video/webm" }));
+    }
+
+    const encryptedThumbnail = await encryptData(key, ivBuffer, thumbnail);
+    await apiUpload(createRes.data.thumbnailUploadToken, new Blob([encryptedThumbnail], { type: "image/webp" }));
+
+    const publishRes = await api.timelapse.publish({
+      id: draftId,
+      visibility: "UNLISTED",
+      deviceKey: device.passkey,
+    });
+
+    if (!publishRes.ok)
+      throw new Error(publishRes.message);
   }
-
-  const encryptedThumbnail = await encryptData(key, ivBuffer, thumbnail);
-  await apiUpload(createRes.data.thumbnailUploadToken, new Blob([encryptedThumbnail], { type: "image/webp" }));
-
-  const publishRes = await api.timelapse.publish({
-    id: createRes.data.draftTimelapse.id,
-    visibility: "UNLISTED",
-    deviceKey: device.passkey,
-  });
-
-  if (!publishRes.ok)
-    throw new Error(publishRes.message);
+  catch (err) {
+    // The draft record exists server-side, but we never finished uploading/publishing it. Left behind, it would
+    // resurface as an orphan "draft" recoverable item (no associated timelapse), so it - and every failed retry -
+    // would pile up in the recovery list and banner count. Delete it so a retry starts clean; keep the local copy.
+    await api.draftTimelapse.delete({ id: draftId }).catch(delErr => {
+      console.warn("(legacyRecovery.ts) failed to clean up partially-created draft after a publish error", delErr);
+    });
+    throw err;
+  }
 
   // Only once the recording is safely published do we drop the local copy.
   await deviceStorage.deleteTimelapse();

--- a/apps/client/src/pages/draft/[id].tsx
+++ b/apps/client/src/pages/draft/[id].tsx
@@ -1,15 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
 import { useRouter } from "next/router";
 import type { DraftTimelapse, TimelapseVisibility } from "@hackclub/lapse-api";
-import { decryptData, fromHex } from "@hackclub/lapse-shared";
 import Icon from "@hackclub/icons";
 import posthog from "posthog-js";
 
 import { api } from "@/api";
 import { useAuth } from "@/hooks/useAuth";
 import { deviceStorage } from "@/deviceStorage";
-import { retryable, sfetch } from "@/safety";
 
+import { useDecryptedThumbnail } from "@/components/entity/ThumbnailImage";
 import RootLayout from "@/components/layout/RootLayout";
 import { Button } from "@/components/ui/Button";
 import { TextInput } from "@/components/ui/TextInput";
@@ -37,9 +36,19 @@ export default function Page() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [thumbnail, setThumbnail] = useState<string | null>(null);
-  // `true` when the draft was recorded on a device whose key isn't available locally - we can't publish it here.
-  const [missingKey, setMissingKey] = useState(false);
+  // Decrypt the (client-encrypted) preview thumbnail so the user can recognise the draft. `missingKey` is set when
+  // the draft was recorded on a device whose key isn't available locally - we can't publish it from here.
+  const { thumbnail, missingKey: thumbMissingKey } = useDecryptedThumbnail({
+    id: draft?.id ?? "",
+    url: draft?.previewThumbnail,
+    iv: draft?.iv ?? "",
+    deviceId: draft?.deviceId,
+    mimeType: "image/webp",
+    enabled: !!draft,
+  });
+  // The publish path re-checks for the device key and can flip this on too.
+  const [missingKeyAtPublish, setMissingKeyAtPublish] = useState(false);
+  const missingKey = thumbMissingKey || missingKeyAtPublish;
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -84,39 +93,6 @@ export default function Page() {
     load();
   }, [router.isReady, load]);
 
-  // Decrypt the (client-encrypted) preview thumbnail so the user can recognise the draft.
-  useEffect(() => {
-    if (!draft) return;
-
-    let objectUrl: string | null = null;
-
-    retryable("decrypting legacy draft thumbnail", async () => {
-      const device = await deviceStorage.getDevice(draft.deviceId);
-      if (!device) {
-        setMissingKey(true);
-        return;
-      }
-
-      const res = await sfetch(draft.previewThumbnail);
-      if (!res.ok) {
-        throw new Error(`HTTP ${res.status} while fetching draft thumbnail`);
-      }
-
-      const decrypted = await decryptData(
-        fromHex(device.passkey).buffer,
-        fromHex(draft.iv).buffer,
-        await res.arrayBuffer()
-      );
-
-      objectUrl = URL.createObjectURL(new Blob([decrypted], { type: "image/webp" }));
-      setThumbnail(objectUrl);
-    });
-
-    return () => {
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-    };
-  }, [draft]);
-
   function handlePublishClick() {
     if (!visibility) return;
     setHackatimeModalOpen(true);
@@ -132,16 +108,18 @@ export default function Page() {
     try {
       const device = await deviceStorage.getDevice(draft.deviceId);
       if (!device) {
-        setMissingKey(true);
+        setMissingKeyAtPublish(true);
         setError("This draft was recorded on a different device, so it can't be published from here.");
         return;
       }
 
-      // Persist the metadata edits the user made before kicking off the (irreversible) publish.
+      // Persist the metadata edits the user made before kicking off the (irreversible) publish. The server requires
+      // a title of at least 2 characters, so anything shorter is treated as "no title" (the server generates one).
+      const trimmedName = name.trim();
       const updateRes = await api.draftTimelapse.update({
         id: draft.id,
         changes: {
-          name: name.trim() || undefined,
+          name: trimmedName.length >= 2 ? trimmedName : undefined,
           description: description.trim(),
           editList: draft.editList,
         },

--- a/apps/client/src/pages/draft/[id].tsx
+++ b/apps/client/src/pages/draft/[id].tsx
@@ -1,0 +1,323 @@
+import { useCallback, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import type { DraftTimelapse, TimelapseVisibility } from "@hackclub/lapse-api";
+import { decryptData, fromHex } from "@hackclub/lapse-shared";
+import Icon from "@hackclub/icons";
+import posthog from "posthog-js";
+
+import { api } from "@/api";
+import { useAuth } from "@/hooks/useAuth";
+import { deviceStorage } from "@/deviceStorage";
+import { retryable, sfetch } from "@/safety";
+
+import RootLayout from "@/components/layout/RootLayout";
+import { Button } from "@/components/ui/Button";
+import { TextInput } from "@/components/ui/TextInput";
+import { LoadingModal } from "@/components/layout/LoadingModal";
+import { ErrorModal } from "@/components/layout/ErrorModal";
+import { VisibilityPicker } from "@/components/layout/VisibilityPicker";
+import { HackatimeSelectModal } from "@/components/layout/HackatimeSelectModal";
+
+/**
+ * Recovery page for legacy ("pre-Lookout") draft timelapses.
+ *
+ * The legacy recording pipeline (canvas/MediaRecorder capture, client-side editing) was removed when we migrated
+ * to Lookout. This page exists so that drafts created with that pipeline can still be *published* - it deliberately
+ * does NOT let the user continue recording or edit the footage. The encrypted sessions are decrypted and re-encoded
+ * server-side via the existing realize job; the client only needs to hand over the device key.
+ */
+export default function Page() {
+  const router = useRouter();
+  useAuth(true);
+
+  const rawId = router.query.id as string | undefined;
+  const draftId = rawId && rawId !== "undefined" ? rawId : undefined;
+
+  const [draft, setDraft] = useState<DraftTimelapse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [thumbnail, setThumbnail] = useState<string | null>(null);
+  // `true` when the draft was recorded on a device whose key isn't available locally - we can't publish it here.
+  const [missingKey, setMissingKey] = useState(false);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [visibility, setVisibility] = useState<TimelapseVisibility | null>(null);
+
+  const [hackatimeModalOpen, setHackatimeModalOpen] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [isDiscarding, setIsDiscarding] = useState(false);
+
+  const load = useCallback(async () => {
+    if (!draftId) return;
+
+    setLoading(true);
+
+    try {
+      const res = await api.draftTimelapse.query({ id: draftId });
+      if (!res.ok) {
+        setError(res.message);
+        return;
+      }
+
+      const fetched = res.data.timelapse;
+
+      // If the draft is already being published, there's an associated (processing) timelapse - send the user there.
+      if (fetched.associatedTimelapseId) {
+        router.replace(`/timelapse/${fetched.associatedTimelapseId}`);
+        return;
+      }
+
+      setDraft(fetched);
+      setName(fetched.name ?? "");
+      setDescription(fetched.description ?? "");
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load draft");
+    } finally {
+      setLoading(false);
+    }
+  }, [draftId, router]);
+
+  useEffect(() => {
+    if (!router.isReady) return;
+    load();
+  }, [router.isReady, load]);
+
+  // Decrypt the (client-encrypted) preview thumbnail so the user can recognise the draft.
+  useEffect(() => {
+    if (!draft) return;
+
+    let objectUrl: string | null = null;
+
+    retryable("decrypting legacy draft thumbnail", async () => {
+      const device = await deviceStorage.getDevice(draft.deviceId);
+      if (!device) {
+        setMissingKey(true);
+        return;
+      }
+
+      const res = await sfetch(draft.previewThumbnail);
+      if (!res.ok) {
+        throw new Error(`HTTP ${res.status} while fetching draft thumbnail`);
+      }
+
+      const decrypted = await decryptData(
+        fromHex(device.passkey).buffer,
+        fromHex(draft.iv).buffer,
+        await res.arrayBuffer()
+      );
+
+      objectUrl = URL.createObjectURL(new Blob([decrypted], { type: "image/webp" }));
+      setThumbnail(objectUrl);
+    });
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [draft]);
+
+  function handlePublishClick() {
+    if (!visibility) return;
+    setHackatimeModalOpen(true);
+  }
+
+  async function publish(hackatimeProject: string | null) {
+    setHackatimeModalOpen(false);
+
+    if (!draft || !visibility) return;
+
+    setIsPublishing(true);
+
+    try {
+      const device = await deviceStorage.getDevice(draft.deviceId);
+      if (!device) {
+        setMissingKey(true);
+        setError("This draft was recorded on a different device, so it can't be published from here.");
+        return;
+      }
+
+      // Persist the metadata edits the user made before kicking off the (irreversible) publish.
+      const updateRes = await api.draftTimelapse.update({
+        id: draft.id,
+        changes: {
+          name: name.trim() || undefined,
+          description: description.trim(),
+          editList: draft.editList,
+        },
+      });
+
+      if (!updateRes.ok) {
+        setError(updateRes.message);
+        return;
+      }
+
+      const res = await api.timelapse.publish({
+        id: draft.id,
+        visibility,
+        deviceKey: device.passkey,
+        ...(hackatimeProject ? { hackatimeProject } : {}),
+      });
+
+      if (!res.ok) {
+        setError(res.message);
+        return;
+      }
+
+      posthog.capture("legacy_timelapse_published", {
+        timelapseId: res.data.timelapse.id,
+        visibility,
+        hackatimeProject,
+      });
+
+      location.href = `/timelapse/${res.data.timelapse.id}`;
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to publish timelapse");
+    } finally {
+      setIsPublishing(false);
+    }
+  }
+
+  async function handleDiscard() {
+    if (!draft) return;
+
+    if (!window.confirm("Are you sure you want to discard this draft? This action cannot be undone."))
+      return;
+
+    setIsDiscarding(true);
+
+    try {
+      const res = await api.draftTimelapse.delete({ id: draft.id });
+      if (!res.ok) {
+        setError(res.message);
+        setIsDiscarding(false);
+        return;
+      }
+
+      posthog.capture("legacy_timelapse_discarded", { draftId: draft.id });
+      router.push(`/user/@${draft.owner.handle}`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to discard draft");
+      setIsDiscarding(false);
+    }
+  }
+
+  if (!draftId || loading) {
+    return (
+      <RootLayout>
+        <LoadingModal isOpen title="Loading" message="Loading draft..." />
+      </RootLayout>
+    );
+  }
+
+  return (
+    <RootLayout>
+      <div className="min-h-screen flex flex-col items-center justify-center px-4 py-12">
+        {draft && (
+          <div className="flex flex-col gap-6 w-full max-w-2xl">
+            <div className="flex flex-col gap-2">
+              <h1 className="text-2xl font-bold">Publish your draft</h1>
+              <p className="text-secondary">
+                This timelapse was recorded with an older version of Lapse. You can&apos;t keep recording it, but you can
+                still publish what you&apos;ve already captured.
+              </p>
+            </div>
+
+            <div className="w-full aspect-video rounded-xl border border-slate overflow-hidden bg-darker flex items-center justify-center">
+              {thumbnail ? (
+                <img src={thumbnail} alt="" className="w-full h-full object-cover" />
+              ) : (
+                <Icon glyph={missingKey ? "private" : "clock-fill"} size={48} className="text-muted" />
+              )}
+            </div>
+
+            {missingKey ? (
+              <div className="flex flex-col gap-4">
+                <div className="flex flex-col gap-1 rounded-xl border border-slate p-4">
+                  <span className="font-bold">Recorded on another device</span>
+                  <p className="text-secondary text-sm">
+                    The key needed to decrypt this draft lives on the device it was recorded on. Open Lapse on that
+                    device to publish it. You can still discard it from here.
+                  </p>
+                </div>
+
+                <Button
+                  onClick={handleDiscard}
+                  disabled={isDiscarding}
+                  kind="destructive"
+                  className="w-full"
+                >
+                  {isDiscarding ? "Discarding..." : "Discard"}
+                </Button>
+              </div>
+            ) : (
+              <>
+                <TextInput
+                  field={{ label: "Name", description: "Give your timelapse a title." }}
+                  value={name}
+                  onChange={setName}
+                  placeholder="My awesome timelapse"
+                  maxLength={60}
+                />
+
+                <TextInput
+                  field={{ label: "Description", description: "An optional description for your timelapse." }}
+                  value={description}
+                  onChange={setDescription}
+                  placeholder="What did you build?"
+                  maxLength={280}
+                />
+
+                <div className="flex flex-col w-full">
+                  <label className="font-bold">Visibility</label>
+                  <p className="text-muted mb-2">Choose who can see your timelapse.</p>
+                  <VisibilityPicker value={visibility} onChange={setVisibility} />
+                </div>
+
+                <div className="flex flex-col gap-2">
+                  <Button
+                    onClick={handlePublishClick}
+                    disabled={!visibility || isPublishing || isDiscarding}
+                    kind="primary"
+                    className="w-full"
+                  >
+                    {isPublishing ? "Publishing..." : "Publish"}
+                  </Button>
+
+                  <Button
+                    onClick={handleDiscard}
+                    disabled={isDiscarding || isPublishing}
+                    kind="destructive"
+                    className="w-full"
+                  >
+                    {isDiscarding ? "Discarding..." : "Discard"}
+                  </Button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      <HackatimeSelectModal
+        isOpen={hackatimeModalOpen}
+        setIsOpen={setHackatimeModalOpen}
+        onAccept={publish}
+        onError={setError}
+      />
+
+      <LoadingModal
+        isOpen={isPublishing}
+        title="Publishing"
+        message="Publishing your timelapse..."
+      />
+
+      <ErrorModal
+        isOpen={!!error}
+        setIsOpen={(open) => !open && setError(null)}
+        message={error || ""}
+        onClose={() => {}}
+      />
+    </RootLayout>
+  );
+}

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/Button";
 import { TimelapseGrid } from "@/components/entity/TimelapseGrid";
 
 import { api } from "@/api";
+import { hasLegacyData } from "@/legacyRecovery";
 import { useAuth } from "@/hooks/useAuth";
 import { useCache } from "@/hooks/useCache";
 import { useCachedApiCall } from "@/hooks/useCachedApiCall";
@@ -29,6 +30,25 @@ export default function Home() {
     time: string,
     percentage: number // [0.0, 1.0], relative to top project. topUserProjects[0].percentage is always 1.0
   }[]>([]);
+
+  // Legacy recordings (unfinished OPFS captures or unpublished drafts) can no longer be recorded, only recovered.
+  // If the user has any, send them to the create page, which surfaces the keep/discard recovery flow.
+  useEffect(() => {
+    if (!auth.currentUser)
+      return;
+
+    if (sessionStorage.getItem("lapse:recovery_dismissed") === "1")
+      return;
+
+    let cancelled = false;
+    (async () => {
+      if (!cancelled && await hasLegacyData(auth.currentUser!.id)) {
+        router.replace("/timelapse/create");
+      }
+    })();
+
+    return () => { cancelled = true; };
+  }, [auth.currentUser, router]);
 
   useEffect(() => {
     (async () => {

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -10,7 +10,6 @@ import { Button } from "@/components/ui/Button";
 import { TimelapseGrid } from "@/components/entity/TimelapseGrid";
 
 import { api } from "@/api";
-import { hasLegacyData, isRecoveryDismissed } from "@/legacyRecovery";
 import { useAuth } from "@/hooks/useAuth";
 import { useCache } from "@/hooks/useCache";
 import { useCachedApiCall } from "@/hooks/useCachedApiCall";
@@ -32,23 +31,7 @@ export default function Home() {
   }[]>([]);
 
   // Legacy recordings (unfinished OPFS captures or unpublished drafts) can no longer be recorded, only recovered.
-  // If the user has any, send them to the create page, which surfaces the keep/discard recovery flow.
-  useEffect(() => {
-    if (!auth.currentUser)
-      return;
-
-    if (isRecoveryDismissed())
-      return;
-
-    let cancelled = false;
-    (async () => {
-      if (!cancelled && await hasLegacyData(auth.currentUser!.id)) {
-        router.replace("/timelapse/create");
-      }
-    })();
-
-    return () => { cancelled = true; };
-  }, [auth.currentUser, router]);
+  // The site-wide banner (see RootLayout) nudges the user to `/timelapse/recover` whenever they have any.
 
   useEffect(() => {
     (async () => {

--- a/apps/client/src/pages/index.tsx
+++ b/apps/client/src/pages/index.tsx
@@ -10,7 +10,7 @@ import { Button } from "@/components/ui/Button";
 import { TimelapseGrid } from "@/components/entity/TimelapseGrid";
 
 import { api } from "@/api";
-import { hasLegacyData } from "@/legacyRecovery";
+import { hasLegacyData, isRecoveryDismissed } from "@/legacyRecovery";
 import { useAuth } from "@/hooks/useAuth";
 import { useCache } from "@/hooks/useCache";
 import { useCachedApiCall } from "@/hooks/useCachedApiCall";
@@ -37,7 +37,7 @@ export default function Home() {
     if (!auth.currentUser)
       return;
 
-    if (sessionStorage.getItem("lapse:recovery_dismissed") === "1")
+    if (isRecoveryDismissed())
       return;
 
     let cancelled = false;

--- a/apps/client/src/pages/timelapse/recover.tsx
+++ b/apps/client/src/pages/timelapse/recover.tsx
@@ -1,0 +1,19 @@
+import dynamic from "next/dynamic";
+
+import RootLayout from "@/components/layout/RootLayout";
+
+const LegacyRecoveryView = dynamic(
+  () => import("@/components/legacy/LegacyRecoveryView").then(m => m.LegacyRecoveryView),
+  {
+    ssr: false,
+    loading: () => (
+      <RootLayout showHeader>
+        <div className="flex items-center justify-center h-screen text-muted">Looking for recordings...</div>
+      </RootLayout>
+    ),
+  },
+);
+
+export default function Page() {
+  return <LegacyRecoveryView />;
+}

--- a/apps/server/src/app.ts
+++ b/apps/server/src/app.ts
@@ -19,8 +19,9 @@ import type { Context } from "@/router.js"
 import { database, initDatabase } from "@/db.js";
 import { env } from "@/env.js"
 import { logError } from "@/logging.js";
-// tus upload server removed — Lookout handles uploads now.
-// import { attachUploadServer } from "@/upload.js";
+// New recordings go through Lookout, but the tus upload server is still needed so legacy drafts
+// (and unfinished OPFS recordings) can be recovered and published. See `legacyRecovery` on the client.
+import { attachUploadServer } from "@/upload.js";
 
 import user from "@/routers/user.js"
 import timelapse from "@/routers/timelapse.js"
@@ -169,7 +170,8 @@ server.all("/docs", async (req, reply) => {
     );
 });
 
-// attachUploadServer(server); — deprecated, Lookout handles uploads
+// Required for legacy draft recovery — lets clients upload encrypted sessions for unfinished recordings.
+attachUploadServer(server);
 
 server.listen({ port: parseInt(env.PORT), host: env.HOST })
     .then(async (address) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       react-dom:
         specifier: 19.2.6
         version: 19.2.6(react@19.2.6)
+      tus-js-client:
+        specifier: ^4.3.1
+        version: 4.3.1
       valibot:
         specifier: ^1.4.1
         version: 1.4.1(typescript@6.0.3)
@@ -4008,6 +4011,9 @@ packages:
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
+  combine-errors@3.0.3:
+    resolution: {integrity: sha512-C8ikRNRMygCwaTx+Ek3Yr+OuZzgZjduCOfSQBjbM8V3MfgcjSTeto/GXP6PAwKvJz/v15b7GHZvx5rOlczFw/Q==}
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -4133,6 +4139,9 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  custom-error-instance@2.1.1:
+    resolution: {integrity: sha512-p6JFxJc3M4OTD2li2qaHkDCw9SfMw82Ldr6OC9Je1aXiGfhx2W8p3GaoeaGrPJTUN9NirTM/KTxHWMUdR1rsUg==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -5043,6 +5052,10 @@ packages:
     resolution: {integrity: sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==}
     engines: {node: '>= 0.4'}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-stream@4.0.1:
     resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
     engines: {node: '>=18'}
@@ -5112,6 +5125,9 @@ packages:
   joycon@3.1.1:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
+
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
@@ -5301,6 +5317,24 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash._baseiteratee@4.7.0:
+    resolution: {integrity: sha512-nqB9M+wITz0BX/Q2xg6fQ8mLkyfF7MU7eE+MNBNjTHFKeKaZAPEzEg+E8LWxKWf1DQVflNEn9N49yAuqKh2mWQ==}
+
+  lodash._basetostring@4.12.0:
+    resolution: {integrity: sha512-SwcRIbyxnN6CFEEK4K1y+zuApvWdpQdBHM/swxP962s8HIxPO3alBH5t3m/dl+f4CMUug6sJb7Pww8d13/9WSw==}
+
+  lodash._baseuniq@4.6.0:
+    resolution: {integrity: sha512-Ja1YevpHZctlI5beLA7oc5KNDhGcPixFhcqSiORHNsp/1QTv7amAXzw+gu4YOvErqVlMVyIJGgtzeepCnnur0A==}
+
+  lodash._createset@4.0.3:
+    resolution: {integrity: sha512-GTkC6YMprrJZCYU3zcqZj+jkXkrXzq3IPBcF/fIPpNEAB4hZEtXU8zp/RwKOvZl43NUmwDbyRk3+ZTbeRdEBXA==}
+
+  lodash._root@3.0.1:
+    resolution: {integrity: sha512-O0pWuFSK6x4EXhM1dhZ8gchNtG7JMqBtrHdoUFUWXD7dJnNSUze1GuyQr5sOs0aCvgGeI3o/OJW8f4ca7FDxmQ==}
+
+  lodash._stringtopath@4.8.0:
+    resolution: {integrity: sha512-SXL66C731p0xPDC5LZg4wI5H+dJo/EO4KTqOMwLYCH3+FmmfAKJEZCm6ohGpI+T1xwsDsJCfL4OnhorllvlTPQ==}
+
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
 
@@ -5333,6 +5367,9 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
+
+  lodash.uniqby@4.5.0:
+    resolution: {integrity: sha512-IRt7cfTtHy6f1aRVA5n7kT8rgN3N1nH6MOWLcHfpWG2SH19E3JksLK38MktLxZDhlAjCP9jpIXkOnRXlu6oByQ==}
 
   log-symbols@7.0.1:
     resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
@@ -5991,6 +6028,9 @@ packages:
   query-selector-shadow-dom@1.0.1:
     resolution: {integrity: sha512-lT5yCqEBgfoMYpf3F2xQRK7zEr1rhIIZuceDK6+xRkJQ4NMbHTwXqk4NkwDwQMNqXgG9r9fyHnzwNVs6zV5KRw==}
 
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
+
   queue-lit@1.5.2:
     resolution: {integrity: sha512-tLc36IOPeMAubu8BkW8YDBV+WyIgKlYU7zUNs0J5Vk9skSZ4JfGlPOqplP0aHdfv7HL0B2Pg6nwiq60Qc6M2Hw==}
     engines: {node: '>=12'}
@@ -6099,6 +6139,9 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -6655,6 +6698,10 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
+  tus-js-client@4.3.1:
+    resolution: {integrity: sha512-ZLeYmjrkaU1fUsKbIi8JML52uAocjEZtBx4DKjRrqzrZa0O4MYwT6db+oqePlspV+FxXJAyFBc/L5gwUi2OFsg==}
+    engines: {node: '>=18'}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -6751,6 +6798,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -10835,6 +10885,11 @@ snapshots:
 
   colorette@2.0.20: {}
 
+  combine-errors@3.0.3:
+    dependencies:
+      custom-error-instance: 2.1.1
+      lodash.uniqby: 4.5.0
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
@@ -10948,6 +11003,8 @@ snapshots:
     optional: true
 
   csstype@3.2.3: {}
+
+  custom-error-instance@2.1.1: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -12109,6 +12166,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-stream@2.0.1: {}
+
   is-stream@4.0.1: {}
 
   is-string@1.1.1:
@@ -12176,6 +12235,8 @@ snapshots:
   jiti@2.7.0: {}
 
   joycon@3.1.1: {}
+
+  js-base64@3.7.8: {}
 
   js-tokens@10.0.0: {}
 
@@ -12366,6 +12427,25 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash._baseiteratee@4.7.0:
+    dependencies:
+      lodash._stringtopath: 4.8.0
+
+  lodash._basetostring@4.12.0: {}
+
+  lodash._baseuniq@4.6.0:
+    dependencies:
+      lodash._createset: 4.0.3
+      lodash._root: 3.0.1
+
+  lodash._createset@4.0.3: {}
+
+  lodash._root@3.0.1: {}
+
+  lodash._stringtopath@4.8.0:
+    dependencies:
+      lodash._basetostring: 4.12.0
+
   lodash.debounce@4.0.8: {}
 
   lodash.defaults@4.2.0: {}
@@ -12387,6 +12467,11 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash.throttle@4.1.1: {}
+
+  lodash.uniqby@4.5.0:
+    dependencies:
+      lodash._baseiteratee: 4.7.0
+      lodash._baseuniq: 4.6.0
 
   log-symbols@7.0.1:
     dependencies:
@@ -13068,6 +13153,8 @@ snapshots:
 
   query-selector-shadow-dom@1.0.1: {}
 
+  querystringify@2.2.0: {}
+
   queue-lit@1.5.2: {}
 
   queue-microtask@1.2.3: {}
@@ -13175,6 +13262,8 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
+
+  requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -13786,6 +13875,16 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
+  tus-js-client@4.3.1:
+    dependencies:
+      buffer-from: 1.1.2
+      combine-errors: 3.0.3
+      is-stream: 2.0.1
+      js-base64: 3.7.8
+      lodash.throttle: 4.1.1
+      proper-lockfile: 4.1.2
+      url-parse: 1.5.10
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -13919,6 +14018,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
Restores the `/draft/[id]` page as a publish-only flow so pre-Lookout draft recordings can be decrypted and published, without reintroducing legacy recording.